### PR TITLE
Fix COEP/COOP not activating for Safari and Firefox

### DIFF
--- a/client-side-media-experiments.php
+++ b/client-side-media-experiments.php
@@ -19,24 +19,33 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-// Bail if client-side media processing is not enabled.
-if ( function_exists( 'wp_is_client_side_media_processing_enabled' ) ) {
-	if ( ! wp_is_client_side_media_processing_enabled() ) {
-		return;
-	}
-} elseif ( function_exists( 'gutenberg_is_client_side_media_processing_enabled' ) ) {
-	if ( ! gutenberg_is_client_side_media_processing_enabled() ) {
-		return;
-	}
-} else {
-	// Neither core 7.0+ nor Gutenberg with the feature — nothing to do.
-	return;
-}
-
 define( 'CSME_VERSION', '0.2.0' );
 define( 'CSME_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'CSME_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
-require_once CSME_PLUGIN_DIR . 'includes/settings.php';
-require_once CSME_PLUGIN_DIR . 'includes/cross-origin-isolation.php';
-require_once CSME_PLUGIN_DIR . 'includes/heic-support.php';
+/**
+ * Initializes the plugin after all plugins have loaded.
+ *
+ * Deferred to plugins_loaded so that Gutenberg's functions are available
+ * regardless of plugin activation order.
+ */
+function csme_init() {
+	// Bail if client-side media processing is not enabled.
+	if ( function_exists( 'wp_is_client_side_media_processing_enabled' ) ) {
+		if ( ! wp_is_client_side_media_processing_enabled() ) {
+			return;
+		}
+	} elseif ( function_exists( 'gutenberg_is_client_side_media_processing_enabled' ) ) {
+		if ( ! gutenberg_is_client_side_media_processing_enabled() ) {
+			return;
+		}
+	} else {
+		// Neither core 7.0+ nor Gutenberg with the feature — nothing to do.
+		return;
+	}
+
+	require_once CSME_PLUGIN_DIR . 'includes/settings.php';
+	require_once CSME_PLUGIN_DIR . 'includes/cross-origin-isolation.php';
+	require_once CSME_PLUGIN_DIR . 'includes/heic-support.php';
+}
+add_action( 'plugins_loaded', 'csme_init' );

--- a/includes/cross-origin-isolation.php
+++ b/includes/cross-origin-isolation.php
@@ -26,8 +26,8 @@ function csme_should_use_coep_coop() {
 
 	if ( function_exists( 'wp_get_chrome_major_version' ) ) {
 		$chrome_version = wp_get_chrome_major_version();
-	} elseif ( function_exists( 'gutenberg_get_chrome_major_version' ) ) {
-		$chrome_version = gutenberg_get_chrome_major_version();
+	} elseif ( function_exists( 'gutenberg_get_chromium_major_version' ) ) {
+		$chrome_version = gutenberg_get_chromium_major_version();
 	}
 
 	// DIP is used on Chrome 137+. Only use COEP/COOP when DIP is NOT active.

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -25,8 +25,8 @@ function csme_get_enabled_default() {
 
 	if ( function_exists( 'wp_get_chrome_major_version' ) ) {
 		$chrome_version = wp_get_chrome_major_version();
-	} elseif ( function_exists( 'gutenberg_get_chrome_major_version' ) ) {
-		$chrome_version = gutenberg_get_chrome_major_version();
+	} elseif ( function_exists( 'gutenberg_get_chromium_major_version' ) ) {
+		$chrome_version = gutenberg_get_chromium_major_version();
 	}
 
 	// Chromium 137+ uses Document-Isolation-Policy; COEP/COOP headers are not needed.

--- a/tests/Test_Should_Use_Coep_Coop.php
+++ b/tests/Test_Should_Use_Coep_Coop.php
@@ -23,7 +23,7 @@ class Test_Should_Use_Coep_Coop extends WP_UnitTestCase {
 	 * Returns true when no Chrome version function exists (Firefox/Safari).
 	 */
 	public function test_returns_true_when_no_chrome_version_function() {
-		// Neither wp_get_chrome_major_version nor gutenberg_get_chrome_major_version
+		// Neither wp_get_chrome_major_version nor gutenberg_get_chromium_major_version
 		// should exist in the test environment by default.
 		$this->assertTrue( csme_should_use_coep_coop() );
 	}


### PR DESCRIPTION
Fixes #20

## Summary

- **Fix plugin load order race condition**: The plugin checked for `gutenberg_is_client_side_media_processing_enabled()` at file include time. If this plugin loaded before Gutenberg (dependent on activation order), the function didn't exist yet and the plugin bailed out entirely — no COEP/COOP headers were ever set. Initialization is now deferred to the `plugins_loaded` hook.

- **Fix wrong Gutenberg function name**: The plugin called `gutenberg_get_chrome_major_version()` but the actual Gutenberg function is `gutenberg_get_chromium_major_version()`. This meant DIP-capable browsers (Chrome 137+) were never detected, and COEP/COOP was always enabled redundantly alongside DIP.

## Test plan

- [ ] Activate both Gutenberg and this plugin (activate this plugin first to reproduce the load order issue)
- [ ] Open the block editor in Safari — verify `Cross-Origin-Embedder-Policy: require-corp` and `Cross-Origin-Opener-Policy: same-origin` headers are present
- [ ] Open the block editor in Firefox — verify `Cross-Origin-Embedder-Policy: credentialless` and `Cross-Origin-Opener-Policy: same-origin` headers are present
- [ ] Confirm `window.crossOriginIsolated` is `true` in both Safari and Firefox
- [ ] Upload an image and verify client-side media processing runs (sub-sizes generated in-browser)
- [ ] Open the block editor in Chrome 137+ — verify DIP header is used instead of COEP/COOP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved plugin initialization sequence for enhanced compatibility
  * Updated Chrome/Chromium version detection for better accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->