### PR TITLE
Only add crossorigin to dynamic IMG under require-corp COEP

### DIFF
--- a/includes/cross-origin-isolation.php
+++ b/includes/cross-origin-isolation.php
@@ -44,6 +44,21 @@ function csme_should_use_coep_coop() {
 }
 
 /**
+ * Returns the COEP mode to use for cross-origin isolation.
+ *
+ * Safari does not support `credentialless`, so it gets `require-corp`.
+ * All other browsers get `credentialless`, which does not require
+ * cross-origin resources to opt in via CORS.
+ *
+ * @return string Either 'require-corp' or 'credentialless'.
+ */
+function csme_get_coep_mode() {
+	global $is_safari;
+
+	return $is_safari ? 'require-corp' : 'credentialless';
+}
+
+/**
  * Sets up cross-origin isolation via COEP/COOP on relevant admin screens.
  *
  * Hooked at priority 20 so it runs after Gutenberg/core's own hooks.
@@ -92,11 +107,9 @@ add_action( 'load-widgets.php', 'csme_set_up_cross_origin_isolation', 20 );
  * @link https://web.dev/coop-coep/
  */
 function csme_start_coep_coop_output_buffer() {
-	global $is_safari;
-
 	ob_start(
-		function ( $output ) use ( $is_safari ) {
-			$coep = $is_safari ? 'require-corp' : 'credentialless';
+		function ( $output ) {
+			$coep = csme_get_coep_mode();
 			header( 'Cross-Origin-Opener-Policy: same-origin' );
 			header( 'Cross-Origin-Embedder-Policy: ' . $coep );
 
@@ -133,8 +146,13 @@ function csme_enqueue_scripts( $hook_suffix ) {
 		true
 	);
 
-	// Flag so the script knows COEP/COOP isolation (not DIP) is active.
-	wp_add_inline_script( 'csme-cross-origin-isolation-coep', 'window.__coepCoopIsolation = true;', 'before' );
+	// Flag so the script knows COEP/COOP isolation (not DIP) is active,
+	// and which COEP mode is in effect (require-corp vs credentialless).
+	wp_add_inline_script(
+		'csme-cross-origin-isolation-coep',
+		'window.__coepCoopIsolation = true; window.__coepMode = ' . wp_json_encode( csme_get_coep_mode() ) . ';',
+		'before'
+	);
 }
 
 add_action( 'admin_enqueue_scripts', 'csme_enqueue_scripts' );

--- a/js/cross-origin-isolation-coep.js
+++ b/js/cross-origin-isolation-coep.js
@@ -19,9 +19,21 @@
 	/**
 	 * Adds crossorigin="anonymous" and credentialless attributes to elements.
 	 *
+	 * IMG elements only get the attribute under require-corp (Safari):
+	 * crossorigin="anonymous" forces CORS-mode fetches, which breaks
+	 * cross-origin images from servers without CORS headers. Under
+	 * credentialless those images load fine without the attribute.
+	 *
 	 * @param {Element} el The element to modify.
 	 */
 	function addCrossOriginAttributes( el ) {
+		if (
+			el.nodeName === 'IMG' &&
+			window.__coepMode !== 'require-corp'
+		) {
+			return;
+		}
+
 		if ( ! el.hasAttribute( 'crossorigin' ) ) {
 			el.setAttribute( 'crossorigin', 'anonymous' );
 		}

--- a/tests/Test_Coep_Mode.php
+++ b/tests/Test_Coep_Mode.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Tests for csme_get_coep_mode().
+ *
+ * @package ClientSideMediaExperiments
+ */
+
+class Test_Coep_Mode extends WP_UnitTestCase {
+
+	/**
+	 * COEP mode is require-corp on Safari.
+	 */
+	public function test_coep_mode_is_require_corp_on_safari() {
+		global $is_safari;
+		$is_safari = true;
+
+		$this->assertSame( 'require-corp', csme_get_coep_mode() );
+	}
+
+	/**
+	 * COEP mode is credentialless on non-Safari (e.g. Firefox).
+	 */
+	public function test_coep_mode_is_credentialless_on_non_safari() {
+		global $is_safari;
+		$is_safari = false;
+
+		$this->assertSame( 'credentialless', csme_get_coep_mode() );
+	}
+}

--- a/tests/Test_Enqueue_Scripts.php
+++ b/tests/Test_Enqueue_Scripts.php
@@ -40,6 +40,41 @@ class Test_Enqueue_Scripts extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Inline script exposes the COEP/COOP isolation flag and the COEP mode.
+	 */
+	public function test_inline_script_exposes_coep_mode() {
+		global $is_safari;
+		$is_safari = false;
+
+		add_filter( 'csme_use_coep_coop', '__return_true' );
+
+		csme_enqueue_scripts( 'post.php' );
+
+		$before = wp_scripts()->get_data( 'csme-cross-origin-isolation-coep', 'before' );
+		$inline = implode( "\n", (array) $before );
+
+		$this->assertStringContainsString( 'window.__coepCoopIsolation = true;', $inline );
+		$this->assertStringContainsString( 'window.__coepMode = "credentialless";', $inline );
+	}
+
+	/**
+	 * Inline script exposes require-corp as the COEP mode on Safari.
+	 */
+	public function test_inline_script_exposes_require_corp_mode_on_safari() {
+		global $is_safari;
+		$is_safari = true;
+
+		add_filter( 'csme_use_coep_coop', '__return_true' );
+
+		csme_enqueue_scripts( 'post.php' );
+
+		$before = wp_scripts()->get_data( 'csme-cross-origin-isolation-coep', 'before' );
+		$inline = implode( "\n", (array) $before );
+
+		$this->assertStringContainsString( 'window.__coepMode = "require-corp";', $inline );
+	}
+
+	/**
 	 * Script is enqueued on post.php.
 	 */
 	public function test_script_enqueued_on_post_php() {


### PR DESCRIPTION
Fixes #31

## Problem

The MutationObserver in `js/cross-origin-isolation-coep.js` added `crossorigin="anonymous"` to dynamically added `IMG` elements on all browsers where COEP/COOP isolation is active. Under `credentialless` COEP (Firefox), the attribute forces CORS-mode fetches, so cross-origin images from servers without `Access-Control-Allow-Origin` headers fail to load - even though `credentialless` would have loaded them fine without the attribute. The attribute is only needed under `require-corp` (Safari).

## Changes

- **`includes/cross-origin-isolation.php`**: Extract the mode decision into `csme_get_coep_mode()` (returns `require-corp` on Safari, `credentialless` otherwise), use it for the output buffer headers, and expose it to JS as `window.__coepMode` alongside the existing `window.__coepCoopIsolation` boolean flag (unchanged, so existing consumers keep working).
- **`js/cross-origin-isolation-coep.js`**: `addCrossOriginAttributes()` now skips the `crossorigin` attribute for `IMG` elements unless `window.__coepMode === 'require-corp'`. Non-IMG elements (script/link/video/source/iframe) are unchanged, matching core's `wp_add_crossorigin_attributes()` behavior.
- **Tests**: New `Test_Coep_Mode.php` covering both modes of `csme_get_coep_mode()`, plus inline-script assertions in `Test_Enqueue_Scripts.php` verifying `__coepMode` is emitted for both Safari and non-Safari.

## Verification

- PHPUnit: 29 tests, the 4 new tests pass; the only failures are the 3 pre-existing `Test_Output_Buffer` header-capture failures unrelated to this change.
- PHPCS: clean.
- End-to-end JS check: served a harness page with real `Cross-Origin-Opener-Policy`/`Cross-Origin-Embedder-Policy` headers (`crossOriginIsolated === true`) and dynamically inserted `img` and `script` elements:
  - `__coepMode = "credentialless"`: IMG gets no `crossorigin`, SCRIPT gets `crossorigin="anonymous"`
  - `__coepMode = "require-corp"`: both IMG and SCRIPT get `crossorigin="anonymous"`

## References

- #18 - the equivalent PHP-side change for server-rendered IMG tags
- Gutenberg removed IMG handling from its crossorigin attribute pass for the same reason (WordPress/gutenberg#76618)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cross-origin isolation compatibility across browsers, including Safari.
  - Adjusted image handling to prevent unnecessary cross-origin attributes when they are not required.
  - Preserved credentialless behavior for supported browsers while using the appropriate isolation mode for Safari.

- **Tests**
  - Added coverage to verify isolation modes and browser-specific script configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->