### PR TITLE
Add PHPStan static analysis at level 5

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -12,6 +12,8 @@ composer.lock
 dist
 node_modules
 phpcs.xml.dist
+phpstan-bootstrap.php
+phpstan.neon.dist
 phpunit.xml.dist
 README.md
 tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,32 @@ jobs:
       - name: Run PHPCS
         run: composer lint
 
+  phpstan:
+    name: Static analysis (PHPStan)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: composer
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: ${{ runner.os }}-composer-phpstan-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-phpstan-
+
+      - name: Install dependencies
+        run: composer update --no-interaction --prefer-dist
+
+      - name: Run PHPStan
+        run: composer phpstan
+
   test:
     name: Test (PHP ${{ matrix.php }} / WP ${{ matrix.wp }})
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -41,6 +41,23 @@ add_filter( 'csme_use_coep_coop', '__return_false' );
 
 ## Development
 
+### Static analysis
+
+The PHP codebase is analyzed with [PHPStan](https://phpstan.org/) at level 5 (configured in `phpstan.neon.dist`). To run it locally:
+
+```bash
+composer install
+composer phpstan
+```
+
+PHPStan also runs in CI and fails the build on new errors. Fix reported issues with real type fixes (accurate docblocks, guards for `false`/`null` returns) rather than ignores - there is no baseline, and the goal is to keep it that way.
+
+### Coding standards
+
+```bash
+composer lint
+```
+
 ### Building a release zip
 
 To package the plugin for the WordPress.org plugin repository (or manual installation), run:

--- a/composer.json
+++ b/composer.json
@@ -12,17 +12,23 @@
 		"dealerdirect/phpcodesniffer-composer-installer": "^1.0",
 		"phpunit/phpunit": "^9.6",
 		"wp-phpunit/wp-phpunit": "^6.8",
-		"yoast/phpunit-polyfills": "^2.0"
+		"yoast/phpunit-polyfills": "^2.0",
+		"phpstan/phpstan": "^2.1",
+		"szepeviktor/phpstan-wordpress": "^2.0",
+		"phpstan/extension-installer": "^1.4",
+		"symfony/polyfill-php80": "^1.37"
 	},
 	"scripts": {
 		"build": "bin/build-zip.sh",
 		"lint": "phpcs",
 		"lint:fix": "phpcbf",
+		"phpstan": "phpstan analyse --memory-limit=2G",
 		"test": "phpunit"
 	},
 	"config": {
 		"allow-plugins": {
-			"dealerdirect/phpcodesniffer-composer-installer": true
+			"dealerdirect/phpcodesniffer-composer-installer": true,
+			"phpstan/extension-installer": true
 		}
 	}
 }

--- a/includes/cross-origin-isolation.php
+++ b/includes/cross-origin-isolation.php
@@ -158,7 +158,7 @@ function csme_add_crossorigin_to_images( $html ) {
 
 	$processor = new WP_HTML_Tag_Processor( $html );
 
-	while ( $processor->next_tag( 'IMG' ) ) {
+	while ( $processor->next_tag( array( 'tag_name' => 'IMG' ) ) ) {
 		if ( null !== $processor->get_attribute( 'crossorigin' ) ) {
 			continue;
 		}

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * PHPStan bootstrap file.
+ *
+ * Defines the plugin constants from client-side-media-experiments.php so
+ * PHPStan can resolve them when analyzing includes/ files independently.
+ *
+ * @package ClientSideMediaExperiments
+ */
+
+define( 'CSME_VERSION', '1.0.0' );
+define( 'CSME_PLUGIN_DIR', __DIR__ . '/' );
+define( 'CSME_PLUGIN_URL', 'https://example.com/wp-content/plugins/client-side-media-experiments/' );

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,13 @@
+# PHPStan configuration.
+#
+# WordPress core stubs and dynamic return type extensions are provided by
+# szepeviktor/phpstan-wordpress, auto-registered via phpstan/extension-installer.
+parameters:
+	level: 5
+	phpVersion: 70400
+	paths:
+		- client-side-media-experiments.php
+		- uninstall.php
+		- includes/
+	bootstrapFiles:
+		- phpstan-bootstrap.php


### PR DESCRIPTION
Fixes #34

## What

Adds [PHPStan](https://phpstan.org/) static analysis at **level 5** with **no baseline**, running locally via `composer phpstan` and in CI.

## Changes

- **Dev dependencies**: `phpstan/phpstan`, `szepeviktor/phpstan-wordpress` (WordPress core stubs + dynamic return type extensions), `phpstan/extension-installer` (auto-registers the extension, with the required `allow-plugins` entry), and `symfony/polyfill-php80` (provides `str_starts_with` etc. signatures - WordPress polyfills these at runtime but the stubs deliberately exclude them).
- **`phpstan.neon.dist`**: level 5, `phpVersion: 70400` to match the `php: >=7.4` requirement, paths covering `client-side-media-experiments.php`, `uninstall.php`, and `includes/`.
- **`phpstan-bootstrap.php`**: defines the `CSME_*` plugin constants so PHPStan can resolve them when analyzing `includes/` files independently. Placed at the repo root (not `tests/`) because the PHPUnit test suite globs all of `tests/` recursively.
- **Composer script**: `composer phpstan` (`phpstan analyse --memory-limit=2G`).
- **CI**: new "Static analysis (PHPStan)" job alongside the existing PHPCS lint job.
- **`.distignore`**: excludes both new dev files from the release zip.
- **README**: documents how to run PHPStan locally and the no-baseline policy.

## Level 5 fixes

Only one code change was needed: `WP_HTML_Tag_Processor::next_tag( 'IMG' )` now passes `array( 'tag_name' => 'IMG' )`, matching the documented query array shape. Equivalent at runtime.

## Verification

- `composer phpstan` - `[OK] No errors` at level 5, no baseline
- `composer lint` - clean
- `composer validate` - valid

Notes on the issue's "consider including `tests/`" suggestion: left out of scope for now to keep the config focused on shipped code; can be added in a follow-up with `php-stubs/wordpress-tests-stubs`.