### PR TITLE
Enable client-side media uploads in the Media Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ WordPress core's client-side media pipeline only runs in the block editor; the c
 
 - Restores cross-origin isolation on the grid screen (`upload.php`), which core does not isolate. On Firefox, Safari, and Chrome < 137 this uses the COEP/COOP headers above; on Chrome 137+ the plugin sends the `Document-Isolation-Policy` header there itself, since core only sends it in the block editor.
 - Intercepts the grid uploader and routes files through the same client-side pipeline the block editor uses: the original image is uploaded via the REST API and thumbnails are generated in the browser, then sideloaded and finalized. HEIC conversion, animated GIF handling, and oversized-file fallbacks are all handled by core's pipeline.
-- Falls back cleanly to the classic server-side upload when the browser does not support client-side processing, so uploads always work.
+- Falls back cleanly to the classic server-side upload when the browser does not support client-side processing.
 
 **Limitations:** only the Media Library **grid** mode is covered. List mode and the separate **Add New Media File** screen (`media-new.php`) continue to upload server-side.
 

--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@ This plugin restores support by sending the older COEP/COOP headers on browsers 
 - Adds `credentialless` attribute to iframes so they continue working under COEP.
 - Filters embed previews for providers that do not support credentialless iframes (Facebook, SmugMug).
 
-### Media Library grid uploads
+### Media Library uploads
 
-WordPress core's client-side media pipeline only runs in the block editor; the classic Media Library at **Media > Library** still uploads through the server. This plugin extends the pipeline to the Media Library grid so images dragged onto (or added through) the grid are processed in the browser:
+WordPress core's client-side media pipeline only runs in the block editor; the classic Media Library at **Media > Library** still uploads through the server. This plugin extends the pipeline to every Media Library upload surface so images are processed in the browser:
 
-- Restores cross-origin isolation on the grid screen (`upload.php`), which core does not isolate. On Firefox, Safari, and Chrome < 137 this uses the COEP/COOP headers above; on Chrome 137+ the plugin sends the `Document-Isolation-Policy` header there itself, since core only sends it in the block editor.
+- Restores cross-origin isolation on the Media Library grid (`upload.php`) and the **Add New Media File** screen (`media-new.php`), neither of which core isolates. On Firefox, Safari, and Chrome < 137 this uses the COEP/COOP headers above; on Chrome 137+ the plugin sends the `Document-Isolation-Policy` header there itself, since core only sends it in the block editor.
 - Intercepts the grid uploader and routes files through the same client-side pipeline the block editor uses: the original image is uploaded via the REST API and thumbnails are generated in the browser, then sideloaded and finalized. HEIC conversion, animated GIF handling, and oversized-file fallbacks are all handled by core's pipeline.
+- Routes the **Add New Media File** screen (`media-new.php`) through the same pipeline, reusing the screen's existing progress and error UI. This is also how the Media Library's **list mode** uploads: its "Add New Media File" button links to this screen, so both Media Library views are covered.
+- Warns before leaving the page while a pipeline upload is in flight, since browser-generated thumbnails that have not been sideloaded yet would be lost (classic uploads finish server-side and need no guard).
 - Falls back cleanly to the classic server-side upload when the browser does not support client-side processing.
-
-**Limitations:** only the Media Library **grid** mode is covered. List mode and the separate **Add New Media File** screen (`media-new.php`) continue to upload server-side.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ This plugin restores support by sending the older COEP/COOP headers on browsers 
 - Adds `credentialless` attribute to iframes so they continue working under COEP.
 - Filters embed previews for providers that do not support credentialless iframes (Facebook, SmugMug).
 
+### Media Library grid uploads
+
+WordPress core's client-side media pipeline only runs in the block editor; the classic Media Library at **Media > Library** still uploads through the server. This plugin extends the pipeline to the Media Library grid so images dragged onto (or added through) the grid are processed in the browser:
+
+- Restores cross-origin isolation on the grid screen (`upload.php`), which core does not isolate. On Firefox, Safari, and Chrome < 137 this uses the COEP/COOP headers above; on Chrome 137+ the plugin sends the `Document-Isolation-Policy` header there itself, since core only sends it in the block editor.
+- Intercepts the grid uploader and routes files through the same client-side pipeline the block editor uses: the original image is uploaded via the REST API and thumbnails are generated in the browser, then sideloaded and finalized. HEIC conversion, animated GIF handling, and oversized-file fallbacks are all handled by core's pipeline.
+- Falls back cleanly to the classic server-side upload when the browser does not support client-side processing, so uploads always work.
+
+**Limitations:** only the Media Library **grid** mode is covered. List mode and the separate **Add New Media File** screen (`media-new.php`) continue to upload server-side.
+
 ## Requirements
 
 - WordPress 6.8+ with the Gutenberg plugin, or WordPress 7.1+.

--- a/client-side-media-everywhere.php
+++ b/client-side-media-everywhere.php
@@ -46,5 +46,6 @@ function csme_init() {
 
 	require_once CSME_PLUGIN_DIR . 'includes/cross-origin-isolation.php';
 	require_once CSME_PLUGIN_DIR . 'includes/media-library.php';
+	require_once CSME_PLUGIN_DIR . 'includes/media-new.php';
 }
 add_action( 'plugins_loaded', 'csme_init' );

--- a/client-side-media-everywhere.php
+++ b/client-side-media-everywhere.php
@@ -45,5 +45,6 @@ function csme_init() {
 	}
 
 	require_once CSME_PLUGIN_DIR . 'includes/cross-origin-isolation.php';
+	require_once CSME_PLUGIN_DIR . 'includes/media-library.php';
 }
 add_action( 'plugins_loaded', 'csme_init' );

--- a/includes/cross-origin-isolation.php
+++ b/includes/cross-origin-isolation.php
@@ -222,17 +222,21 @@ function csme_enqueue_scripts( $hook_suffix ) {
 		return;
 	}
 
-	$is_media_library = 'upload.php' === $hook_suffix;
+	$is_media_screen = in_array( $hook_suffix, array( 'upload.php', 'media-new.php' ), true );
 
-	if ( $is_media_library ) {
-		// Only the grid mode has an uploader; list mode is untouched.
+	if ( 'upload.php' === $hook_suffix ) {
+		// Only the grid mode has an uploader; list mode uploads happen on
+		// media-new.php (the list view's "Add New Media File" links there).
 		if ( 'grid' !== csme_get_media_library_mode() ) {
 			return;
 		}
+	}
 
-		// No isolation headers are sent on the grid without the
-		// upload-media package (see csme_set_up_media_library_isolation()),
-		// so the observer script would be dead weight.
+	if ( $is_media_screen ) {
+		// No isolation headers are sent on these screens without the
+		// upload-media package (see csme_set_up_media_library_isolation()
+		// and csme_set_up_media_new_isolation()), so the observer script
+		// would be dead weight.
 		if ( ! wp_script_is( 'wp-upload-media', 'registered' ) ) {
 			return;
 		}
@@ -242,10 +246,10 @@ function csme_enqueue_scripts( $hook_suffix ) {
 
 	/*
 	 * The MutationObserver portion of the script is dependency-free and
-	 * its block editor section self-guards, so the Media Library does
+	 * its block editor section self-guards, so the media screens do
 	 * not need the block editor scripts dragged onto the page.
 	 */
-	$dependencies = $is_media_library
+	$dependencies = $is_media_screen
 		? array()
 		: array( 'wp-block-editor', 'wp-element', 'wp-hooks', 'wp-compose' );
 

--- a/includes/cross-origin-isolation.php
+++ b/includes/cross-origin-isolation.php
@@ -229,6 +229,13 @@ function csme_enqueue_scripts( $hook_suffix ) {
 		if ( 'grid' !== csme_get_media_library_mode() ) {
 			return;
 		}
+
+		// No isolation headers are sent on the grid without the
+		// upload-media package (see csme_set_up_media_library_isolation()),
+		// so the observer script would be dead weight.
+		if ( ! wp_script_is( 'wp-upload-media', 'registered' ) ) {
+			return;
+		}
 	} elseif ( ! in_array( $hook_suffix, array( 'post.php', 'post-new.php', 'site-editor.php', 'widgets.php' ), true ) ) {
 		return;
 	}

--- a/includes/cross-origin-isolation.php
+++ b/includes/cross-origin-isolation.php
@@ -222,14 +222,30 @@ function csme_enqueue_scripts( $hook_suffix ) {
 		return;
 	}
 
-	if ( ! in_array( $hook_suffix, array( 'post.php', 'post-new.php', 'site-editor.php', 'widgets.php' ), true ) ) {
+	$is_media_library = 'upload.php' === $hook_suffix;
+
+	if ( $is_media_library ) {
+		// Only the grid mode has an uploader; list mode is untouched.
+		if ( 'grid' !== csme_get_media_library_mode() ) {
+			return;
+		}
+	} elseif ( ! in_array( $hook_suffix, array( 'post.php', 'post-new.php', 'site-editor.php', 'widgets.php' ), true ) ) {
 		return;
 	}
+
+	/*
+	 * The MutationObserver portion of the script is dependency-free and
+	 * its block editor section self-guards, so the Media Library does
+	 * not need the block editor scripts dragged onto the page.
+	 */
+	$dependencies = $is_media_library
+		? array()
+		: array( 'wp-block-editor', 'wp-element', 'wp-hooks', 'wp-compose' );
 
 	wp_enqueue_script(
 		'csme-cross-origin-isolation-coep',
 		CSME_PLUGIN_URL . 'js/cross-origin-isolation-coep.js',
-		array( 'wp-block-editor', 'wp-element', 'wp-hooks', 'wp-compose' ),
+		$dependencies,
 		CSME_VERSION,
 		true
 	);

--- a/includes/media-library.php
+++ b/includes/media-library.php
@@ -74,3 +74,96 @@ function csme_set_up_media_library_isolation() {
 }
 
 add_action( 'load-upload.php', 'csme_set_up_media_library_isolation', 20 );
+
+/**
+ * Enqueues the client-side upload integration on the Media Library grid.
+ *
+ * Wanted under both the DIP and the COEP/COOP isolation paths, so this is
+ * not gated on csme_should_use_coep_coop(). The script itself no-ops when
+ * the browser lacks client-side media support, leaving classic plupload
+ * untouched.
+ *
+ * @since 1.2.0
+ *
+ * @param string $hook_suffix The current admin page hook suffix.
+ */
+function csme_enqueue_media_library_scripts( $hook_suffix ) {
+	if ( 'upload.php' !== $hook_suffix ) {
+		return;
+	}
+
+	if ( 'grid' !== csme_get_media_library_mode() ) {
+		return;
+	}
+
+	// Core 7.1+ (or Gutenberg) must have registered the upload-media package.
+	if ( ! wp_script_is( 'wp-upload-media', 'registered' ) ) {
+		return;
+	}
+
+	wp_enqueue_script(
+		'csme-media-library-upload',
+		CSME_PLUGIN_URL . 'js/media-library-upload.js',
+		array(
+			'media-views',
+			'wp-upload-media',
+			'wp-media-utils',
+			'wp-api-fetch',
+			'wp-data',
+			'wp-element',
+			'wp-i18n',
+		),
+		CSME_VERSION,
+		true
+	);
+
+	wp_add_inline_script(
+		'csme-media-library-upload',
+		'window.csmeMediaLibrarySettings = ' . wp_json_encode( csme_get_media_library_settings() ) . ';',
+		'before'
+	);
+}
+
+add_action( 'admin_enqueue_scripts', 'csme_enqueue_media_library_scripts' );
+
+/**
+ * Builds the settings passed to the client-side media pipeline.
+ *
+ * These mirror the values the block editor consumes for the same
+ * pipeline: the REST index (image sizes and the big-image threshold)
+ * and get_block_editor_settings() (max upload size and allowed mime
+ * types), plus the image encoding filters.
+ *
+ * @since 1.2.0
+ *
+ * @return array{
+ *     maxUploadFileSize:int,
+ *     allowedMimeTypes:array<string,string>,
+ *     allImageSizes:array<string,array<string,mixed>>,
+ *     bigImageSizeThreshold:int,
+ *     imageStripMeta:bool,
+ *     imageMaxBitDepth:int
+ * } Settings for the client-side pipeline.
+ */
+function csme_get_media_library_settings() {
+	/** This filter is documented in wp-admin/includes/image.php */
+	// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+	$big_image_size_threshold = (int) apply_filters( 'big_image_size_threshold', 2560, array( 0, 0 ), '', 0 );
+
+	/** This filter is documented in wp-includes/class-wp-image-editor-imagick.php */
+	// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+	$image_strip_meta = (bool) apply_filters( 'image_strip_meta', true );
+
+	/** This filter is documented in wp-includes/class-wp-image-editor-imagick.php */
+	// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+	$image_max_bit_depth = (int) apply_filters( 'image_max_bit_depth', 16, 16 );
+
+	return array(
+		'maxUploadFileSize'     => wp_max_upload_size(),
+		'allowedMimeTypes'      => get_allowed_mime_types(),
+		'allImageSizes'         => wp_get_registered_image_subsizes(),
+		'bigImageSizeThreshold' => $big_image_size_threshold,
+		'imageStripMeta'        => $image_strip_meta,
+		'imageMaxBitDepth'      => $image_max_bit_depth,
+	);
+}

--- a/includes/media-library.php
+++ b/includes/media-library.php
@@ -28,10 +28,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 function csme_get_media_library_mode() {
 	$modes = array( 'grid', 'list' );
 
-	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	if ( isset( $_GET['mode'] ) && in_array( sanitize_key( $_GET['mode'] ), $modes, true ) ) {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		return sanitize_key( $_GET['mode'] );
+	/*
+	 * Match core: compare the raw value against the whitelist, so inputs
+	 * core rejects (e.g. `?mode=GRID`) fall back to the user option here
+	 * too. The strict whitelist comparison doubles as sanitization.
+	 */
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+	$requested = isset( $_GET['mode'] ) ? wp_unslash( $_GET['mode'] ) : '';
+	if ( in_array( $requested, $modes, true ) ) {
+		return $requested;
 	}
 
 	$mode = get_user_option( 'media_library_mode', get_current_user_id() );

--- a/includes/media-library.php
+++ b/includes/media-library.php
@@ -69,6 +69,16 @@ function csme_set_up_media_library_isolation() {
 		return;
 	}
 
+	/*
+	 * Without the upload-media package (core 7.1+ or Gutenberg) the
+	 * pipeline cannot run, so skip the isolation headers: COEP can break
+	 * third-party iframes on the screen for no benefit. Default scripts
+	 * register on the first wp_scripts() call, so this is reliable here.
+	 */
+	if ( ! wp_script_is( 'wp-upload-media', 'registered' ) ) {
+		return;
+	}
+
 	if ( csme_should_use_coep_coop() ) {
 		csme_start_coep_coop_output_buffer();
 	} elseif ( function_exists( 'wp_start_cross_origin_isolation_output_buffer' ) ) {

--- a/includes/media-library.php
+++ b/includes/media-library.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Client-side media support for the Media Library grid.
+ *
+ * Extends cross-origin isolation to wp-admin/upload.php (grid mode) so
+ * the client-side media pipeline can run there. Core only isolates the
+ * block editor screens, so both the COEP/COOP path (Firefox, Safari,
+ * Chrome < 137) and the Document-Isolation-Policy path (Chromium 137+)
+ * need to be set up by the plugin on this screen.
+ *
+ * @package ClientSideMediaEverywhere
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Returns the current Media Library mode (grid or list).
+ *
+ * Replicates the mode resolution in wp-admin/upload.php, which runs
+ * after the load-upload.php hook this plugin uses.
+ *
+ * @since 1.2.0
+ *
+ * @return string Either 'grid' or 'list'.
+ */
+function csme_get_media_library_mode() {
+	$modes = array( 'grid', 'list' );
+
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	if ( isset( $_GET['mode'] ) && in_array( sanitize_key( $_GET['mode'] ), $modes, true ) ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		return sanitize_key( $_GET['mode'] );
+	}
+
+	$mode = get_user_option( 'media_library_mode', get_current_user_id() );
+
+	return in_array( $mode, $modes, true ) ? $mode : 'grid';
+}
+
+/**
+ * Sets up cross-origin isolation on the Media Library grid screen.
+ *
+ * Unlike the block editor screens, core does not isolate upload.php at
+ * all, so the DIP path (Chromium 137+) also needs to be started here
+ * via core's public output buffer function.
+ *
+ * Hooked at priority 20 to match the block editor screen hooks.
+ *
+ * @since 1.2.0
+ */
+function csme_set_up_media_library_isolation() {
+	if ( 'grid' !== csme_get_media_library_mode() ) {
+		return;
+	}
+
+	$user_id = get_current_user_id();
+	if ( ! $user_id ) {
+		return;
+	}
+
+	if ( ! user_can( $user_id, 'upload_files' ) ) {
+		return;
+	}
+
+	if ( csme_should_use_coep_coop() ) {
+		csme_start_coep_coop_output_buffer();
+	} elseif ( function_exists( 'wp_start_cross_origin_isolation_output_buffer' ) ) {
+		wp_start_cross_origin_isolation_output_buffer();
+	} elseif ( function_exists( 'gutenberg_start_cross_origin_isolation_output_buffer' ) ) {
+		gutenberg_start_cross_origin_isolation_output_buffer();
+	}
+}
+
+add_action( 'load-upload.php', 'csme_set_up_media_library_isolation', 20 );

--- a/includes/media-new.php
+++ b/includes/media-new.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Client-side media support for the "Add New Media File" screen.
+ *
+ * Extends cross-origin isolation to wp-admin/media-new.php so the
+ * client-side media pipeline can run there. The screen is also where
+ * the Media Library's list mode sends users to upload (its "Add New
+ * Media File" button links here), so together with the grid integration
+ * this covers the whole Media Library. Core only isolates the block
+ * editor screens, so both the COEP/COOP path (Firefox, Safari,
+ * Chrome < 137) and the Document-Isolation-Policy path (Chromium 137+)
+ * need to be set up by the plugin on this screen.
+ *
+ * @package ClientSideMediaEverywhere
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Sets up cross-origin isolation on the "Add New Media File" screen.
+ *
+ * Unlike the block editor screens, core does not isolate media-new.php
+ * at all, so the DIP path (Chromium 137+) also needs to be started here
+ * via core's public output buffer function.
+ *
+ * Hooked at priority 20 to match the block editor screen hooks.
+ *
+ * @since 1.2.0
+ */
+function csme_set_up_media_new_isolation() {
+	/*
+	 * The screen itself dies without upload_files, but this hook fires
+	 * before that check runs, so gate here too.
+	 */
+	$user_id = get_current_user_id();
+	if ( ! $user_id ) {
+		return;
+	}
+
+	if ( ! user_can( $user_id, 'upload_files' ) ) {
+		return;
+	}
+
+	/*
+	 * Without the upload-media package (core 7.1+ or Gutenberg) the
+	 * pipeline cannot run, so skip the isolation headers: COEP can break
+	 * third-party iframes on the screen for no benefit. Default scripts
+	 * register on the first wp_scripts() call, so this is reliable here.
+	 */
+	if ( ! wp_script_is( 'wp-upload-media', 'registered' ) ) {
+		return;
+	}
+
+	if ( csme_should_use_coep_coop() ) {
+		csme_start_coep_coop_output_buffer();
+	} elseif ( function_exists( 'wp_start_cross_origin_isolation_output_buffer' ) ) {
+		wp_start_cross_origin_isolation_output_buffer();
+	} elseif ( function_exists( 'gutenberg_start_cross_origin_isolation_output_buffer' ) ) {
+		gutenberg_start_cross_origin_isolation_output_buffer();
+	}
+}
+
+add_action( 'load-media-new.php', 'csme_set_up_media_new_isolation', 20 );
+
+/**
+ * Enqueues the client-side upload integration on the "Add New Media File"
+ * screen.
+ *
+ * Wanted under both the DIP and the COEP/COOP isolation paths, so this is
+ * not gated on csme_should_use_coep_coop(). The script itself no-ops when
+ * the browser lacks client-side media support, leaving classic plupload
+ * untouched.
+ *
+ * @since 1.2.0
+ *
+ * @param string $hook_suffix The current admin page hook suffix.
+ */
+function csme_enqueue_media_new_scripts( $hook_suffix ) {
+	if ( 'media-new.php' !== $hook_suffix ) {
+		return;
+	}
+
+	// Core 7.1+ (or Gutenberg) must have registered the upload-media package.
+	if ( ! wp_script_is( 'wp-upload-media', 'registered' ) ) {
+		return;
+	}
+
+	wp_enqueue_script(
+		'csme-media-new-upload',
+		CSME_PLUGIN_URL . 'js/media-new-upload.js',
+		array(
+			'plupload-handlers',
+			'wp-upload-media',
+			'wp-media-utils',
+			'wp-api-fetch',
+			'wp-data',
+			'wp-element',
+			'wp-i18n',
+		),
+		CSME_VERSION,
+		true
+	);
+
+	// The pipeline settings are identical to the grid's.
+	wp_add_inline_script(
+		'csme-media-new-upload',
+		'window.csmeMediaNewSettings = ' . wp_json_encode( csme_get_media_library_settings() ) . ';',
+		'before'
+	);
+}
+
+add_action( 'admin_enqueue_scripts', 'csme_enqueue_media_new_scripts' );

--- a/js/media-library-upload.js
+++ b/js/media-library-upload.js
@@ -52,8 +52,9 @@
 	var settings = window.csmeMediaLibrarySettings || {};
 	var uploadStore = wp.uploadMedia.store;
 
-	// Map from a file identity key to the placeholder Attachment model, used
-	// to reflect pipeline progress back onto the grid tile.
+	// Map from a file identity key to the placeholder Attachment models
+	// (an array: concurrent uploads of an identical file share a key), used
+	// to reflect pipeline progress back onto the grid tiles.
 	var progressModels = new Map();
 
 	/**
@@ -62,6 +63,8 @@
 	 * The queue item's `sourceFile` is a clone of the original file, so it
 	 * cannot be matched by reference. The clone preserves name, size, and
 	 * last-modified time, which together identify a file within one session.
+	 * Two in-flight uploads of the same file collide on this key, so keys
+	 * map to arrays of models and progress is mirrored to all of them.
 	 *
 	 * @param {File} file The file to key.
 	 * @return {string} Identity key.
@@ -203,8 +206,12 @@
 	 * @param {Object} model The Attachment model to stop tracking.
 	 */
 	function stopTrackingProgress( model ) {
-		progressModels.forEach( function ( tracked, key ) {
-			if ( tracked === model ) {
+		progressModels.forEach( function ( models, key ) {
+			var index = models.indexOf( model );
+			if ( index !== -1 ) {
+				models.splice( index, 1 );
+			}
+			if ( models.length === 0 ) {
 				progressModels.delete( key );
 			}
 		} );
@@ -350,7 +357,13 @@
 			wpUploader.added( model );
 
 			var nativeFile = file.getNative();
-			progressModels.set( fileKey( nativeFile ), model );
+			var key = fileKey( nativeFile );
+			var models = progressModels.get( key );
+			if ( models ) {
+				models.push( model );
+			} else {
+				progressModels.set( key, [ model ] );
+			}
 
 			// Remove the file from plupload so it is not uploaded twice.
 			up.removeFile( file );
@@ -405,14 +418,15 @@
 				return;
 			}
 
-			var model = progressModels.get( fileKey( item.sourceFile ) );
-			if ( ! model ) {
+			var models = progressModels.get( fileKey( item.sourceFile ) );
+			if ( ! models ) {
 				return;
 			}
 
 			if ( typeof item.progress === 'number' ) {
-				model.set( {
-					percent: Math.min( 99, Math.round( item.progress ) ),
+				var percent = Math.min( 99, Math.round( item.progress ) );
+				models.forEach( function ( model ) {
+					model.set( { percent: percent } );
 				} );
 			}
 		} );

--- a/js/media-library-upload.js
+++ b/js/media-library-upload.js
@@ -1,0 +1,420 @@
+/**
+ * Routes Media Library grid uploads through the client-side media pipeline.
+ *
+ * On wp-admin/upload.php (grid mode) WordPress uploads via wp.Uploader /
+ * plupload to async-upload.php. When the browser is cross-origin isolated
+ * and supports the client-side pipeline, this script intercepts the
+ * uploader's FilesAdded handler and routes files through
+ * @wordpress/upload-media instead: the original image is uploaded via the
+ * REST API and thumbnails are generated in the browser (wasm-vips), then
+ * sideloaded and finalized.
+ *
+ * When client-side support is unavailable the script cleanly no-ops and
+ * the classic plupload flow is left untouched.
+ */
+
+/* global wp, plupload */
+
+( function () {
+	// Guard against double execution (e.g. duplicate enqueues).
+	if ( window.__csmeMediaLibraryUpload ) {
+		return;
+	}
+
+	// Require every dependency the integration relies on.
+	if (
+		typeof wp === 'undefined' ||
+		typeof plupload === 'undefined' ||
+		! wp.Uploader ||
+		! wp.uploadMedia ||
+		! wp.mediaUtils ||
+		! wp.data ||
+		! wp.element ||
+		! wp.apiFetch ||
+		! wp.media
+	) {
+		return;
+	}
+
+	// Bail unless the browser actually supports client-side processing. This
+	// is the clean no-op: when the isolation headers did not land, classic
+	// plupload keeps handling uploads.
+	if (
+		! wp.uploadMedia.detectClientSideMediaSupport ||
+		! wp.uploadMedia.detectClientSideMediaSupport().supported
+	) {
+		return;
+	}
+
+	window.__csmeMediaLibraryUpload = true;
+
+	var __ = wp.i18n.__;
+	var settings = window.csmeMediaLibrarySettings || {};
+	var uploadStore = wp.uploadMedia.store;
+
+	// Map from a file identity key to the placeholder Attachment model, used
+	// to reflect pipeline progress back onto the grid tile.
+	var progressModels = new Map();
+
+	/**
+	 * Builds a stable identity key for a File.
+	 *
+	 * The queue item's `sourceFile` is a clone of the original file, so it
+	 * cannot be matched by reference. The clone preserves name, size, and
+	 * last-modified time, which together identify a file within one session.
+	 *
+	 * @param {File} file The file to key.
+	 * @return {string} Identity key.
+	 */
+	function fileKey( file ) {
+		return file.name + '::' + file.size + '::' + file.lastModified;
+	}
+
+	/**
+	 * Recursively appends data to a FormData object, supporting nested objects.
+	 *
+	 * Mirrors flattenFormData() in @wordpress/media-utils.
+	 *
+	 * @param {FormData}      formData The form data to append to.
+	 * @param {string}        key      The key to append under.
+	 * @param {string|Object} data     The value to append.
+	 */
+	function flattenFormData( formData, key, data ) {
+		if (
+			data !== null &&
+			typeof data === 'object' &&
+			Object.getPrototypeOf( data ) === Object.prototype
+		) {
+			Object.keys( data ).forEach( function ( name ) {
+				flattenFormData( formData, key + '[' + name + ']', data[ name ] );
+			} );
+		} else if ( data !== undefined ) {
+			formData.append( key, String( data ) );
+		}
+	}
+
+	/**
+	 * Sideloads a client-generated thumbnail to an existing attachment.
+	 *
+	 * Reimplements the private sideloadMedia() helper from
+	 * @wordpress/media-utils as a thin apiFetch wrapper.
+	 *
+	 * @param {Object} args The sideload arguments.
+	 */
+	function csmeMediaSideload( args ) {
+		var file = args.file;
+		var additionalData = args.additionalData || {};
+
+		var data = new FormData();
+		data.append( 'file', file, file.name || file.type.replace( '/', '.' ) );
+		Object.keys( additionalData ).forEach( function ( key ) {
+			flattenFormData( data, key, additionalData[ key ] );
+		} );
+
+		wp.apiFetch( {
+			path: '/wp/v2/media/' + args.attachmentId + '/sideload',
+			body: data,
+			method: 'POST',
+			signal: args.signal,
+		} )
+			.then( function ( subSize ) {
+				if ( args.onSuccess ) {
+					args.onSuccess( subSize );
+				}
+			} )
+			.catch( function ( error ) {
+				if ( args.onError ) {
+					args.onError(
+						error instanceof Error
+							? error
+							: new Error( String( error ) )
+					);
+				}
+			} );
+	}
+
+	/**
+	 * Finalizes an upload once all client-side processing is complete.
+	 *
+	 * Reimplements the private mediaFinalize() helper. The returned
+	 * attachment is load-bearing: it carries the post-finalize (scaled)
+	 * URL used for srcset.
+	 *
+	 * @param {number} id       The parent attachment ID.
+	 * @param {Array}  subSizes Accumulated sub-size data.
+	 * @return {Promise} Resolves with the transformed attachment.
+	 */
+	function csmeMediaFinalize( id, subSizes ) {
+		return wp
+			.apiFetch( {
+				path: '/wp/v2/media/' + id + '/finalize',
+				method: 'POST',
+				data: { sub_sizes: subSizes || [] },
+			} )
+			.then( function ( response ) {
+				return response
+					? wp.mediaUtils.transformAttachment( response )
+					: undefined;
+			} );
+	}
+
+	// Configure the default-registry upload-media store once. Rendering the
+	// provider with useSubRegistry: false wires the settings into the store
+	// that wp.data.dispatch/select address (the block editor does the same).
+	var pipelineSettings = {
+		mediaUpload: wp.mediaUtils.uploadMedia,
+		mediaSideload: csmeMediaSideload,
+		mediaFinalize: csmeMediaFinalize,
+		maxUploadFileSize: settings.maxUploadFileSize,
+		allowedMimeTypes: settings.allowedMimeTypes,
+		allImageSizes: settings.allImageSizes,
+		bigImageSizeThreshold: settings.bigImageSizeThreshold,
+		imageStripMeta: settings.imageStripMeta,
+		imageMaxBitDepth: settings.imageMaxBitDepth,
+	};
+
+	wp.element
+		.createRoot( document.createElement( 'div' ) )
+		.render(
+			wp.element.createElement( wp.uploadMedia.MediaUploadProvider, {
+				settings: pipelineSettings,
+				useSubRegistry: false,
+			} )
+		);
+
+	/**
+	 * Resets the upload queue once every attachment has finished uploading.
+	 *
+	 * Parity with wp-plupload.js so browse mode flips back when done.
+	 */
+	function maybeResetQueue() {
+		var complete = wp.Uploader.queue.all( function ( attachment ) {
+			return ! attachment.get( 'uploading' );
+		} );
+
+		if ( complete ) {
+			wp.Uploader.queue.reset();
+		}
+	}
+
+	/**
+	 * Removes a model from the progress map.
+	 *
+	 * @param {Object} model The Attachment model to stop tracking.
+	 */
+	function stopTrackingProgress( model ) {
+		progressModels.forEach( function ( tracked, key ) {
+			if ( tracked === model ) {
+				progressModels.delete( key );
+			}
+		} );
+	}
+
+	/**
+	 * Handles a completed upload by syncing the grid tile with the server data.
+	 *
+	 * @param {Object} model      The placeholder Attachment model.
+	 * @param {Object} attachment The finalized attachment from the pipeline.
+	 */
+	function handleSuccess( model, attachment ) {
+		model.set( { id: attachment.id }, { silent: true } );
+
+		// Register the model in Attachments.all (parity with wp-plupload.js).
+		wp.media.model.Attachment.get( attachment.id, model );
+
+		model
+			.fetch()
+			.done( function () {
+				[ 'file', 'loaded', 'size', 'percent' ].forEach( function (
+					key
+				) {
+					model.unset( key, { silent: true } );
+				} );
+				model.set( { uploading: false } );
+			} )
+			.fail( function () {
+				// Fetch failed, but the upload succeeded: clear the uploading
+				// state with what the pipeline gave us so no tile is stuck.
+				[ 'file', 'loaded', 'size', 'percent' ].forEach( function (
+					key
+				) {
+					model.unset( key, { silent: true } );
+				} );
+				model.set( attachment );
+				model.set( { uploading: false } );
+			} )
+			.always( function () {
+				stopTrackingProgress( model );
+				maybeResetQueue();
+			} );
+	}
+
+	/**
+	 * Handles an upload error by removing the tile and surfacing the message.
+	 *
+	 * @param {Object} model    The placeholder Attachment model.
+	 * @param {Error}  error    The upload error.
+	 * @param {File}   nativeFile The original file (for the error label).
+	 */
+	function handleError( model, error, nativeFile ) {
+		var message =
+			( wp.uploadMedia.getErrorMessage &&
+				wp.uploadMedia.getErrorMessage( error ) ) ||
+			( error && error.message ) ||
+			__(
+				'An error occurred while uploading the file.',
+				'client-side-media-everywhere'
+			);
+
+		model.destroy();
+
+		wp.Uploader.errors.unshift( {
+			message: message,
+			data: {},
+			file: { name: nativeFile.name },
+		} );
+
+		stopTrackingProgress( model );
+		maybeResetQueue();
+	}
+
+	/**
+	 * Dispatches a single file into the client-side pipeline.
+	 *
+	 * @param {File}   nativeFile The original file to upload.
+	 * @param {Object} model      The placeholder Attachment model.
+	 */
+	function uploadFile( nativeFile, model ) {
+		wp.data.dispatch( uploadStore ).addItems( {
+			files: [ nativeFile ],
+			onSuccess: function ( attachments ) {
+				handleSuccess( model, attachments[ 0 ] );
+			},
+			onError: function ( error ) {
+				handleError( model, error, nativeFile );
+			},
+		} );
+	}
+
+	/**
+	 * Intercepts files added to a plupload uploader.
+	 *
+	 * Returns undefined (not false) when the store is not yet configured so
+	 * the built-in handler runs and uploads server-side - a degradation, never
+	 * data loss. Otherwise builds the same placeholder tiles as wp-plupload,
+	 * routes each file through the pipeline, and returns false to suppress the
+	 * built-in handler.
+	 *
+	 * @param {Object} wpUploader The wp.Uploader instance.
+	 * @param {Object} up         The plupload uploader instance.
+	 * @param {Array}  files      Files added to the queue.
+	 * @return {boolean|undefined} False to suppress the built-in handler.
+	 */
+	function handleFilesAdded( wpUploader, up, files ) {
+		var storeSettings = wp.data.select( uploadStore ).getSettings();
+
+		// Safety valve: if settings never landed, defer to classic plupload.
+		if ( ! storeSettings || ! storeSettings.mediaUpload ) {
+			return;
+		}
+
+		files.forEach( function ( file ) {
+			// Ignore failed uploads.
+			if ( plupload.FAILED === file.status ) {
+				return;
+			}
+
+			// Build the same placeholder attributes as wp-plupload.js so the
+			// grid's progress tiles and "Uploading n/m" status work unchanged.
+			var attributes = {
+				file: file,
+				uploading: true,
+				date: new Date(),
+				filename: file.name,
+				menuOrder: 0,
+				uploadedTo: wp.media.model.settings.post.id,
+				loaded: file.loaded,
+				size: file.size,
+				percent: file.percent,
+			};
+
+			var image = /(?:jpe?g|png|gif)$/i.exec( file.name );
+			if ( image ) {
+				attributes.type = 'image';
+				// `jpg` is not a valid subtype, so map it to `jpeg`.
+				attributes.subtype = 'jpg' === image[ 0 ] ? 'jpeg' : image[ 0 ];
+			}
+
+			var model = wp.media.model.Attachment.create( attributes );
+			wp.Uploader.queue.add( model );
+			wpUploader.added( model );
+
+			var nativeFile = file.getNative();
+			progressModels.set( fileKey( nativeFile ), model );
+
+			// Remove the file from plupload so it is not uploaded twice.
+			up.removeFile( file );
+
+			uploadFile( nativeFile, model );
+		} );
+
+		up.refresh();
+
+		return false;
+	}
+
+	// Wrap wp.Uploader.prototype.init (an empty stub called once per instance
+	// after plupload is initialized) to bind a higher-priority FilesAdded
+	// handler on every uploader instance, including the Media Library grid's.
+	var originalInit = wp.Uploader.prototype.init;
+	wp.Uploader.prototype.init = function () {
+		originalInit.apply( this, arguments );
+
+		var wpUploader = this;
+		var up = this.uploader;
+
+		if ( ! up || up.__csmeBound ) {
+			return;
+		}
+		up.__csmeBound = true;
+
+		// plupload sorts handlers by priority (descending) and a `false`
+		// return breaks the chain, so priority 100 runs before and suppresses
+		// the built-in FilesAdded handler.
+		up.bind(
+			'FilesAdded',
+			function ( uploader, files ) {
+				return handleFilesAdded( wpUploader, uploader, files );
+			},
+			this,
+			100
+		);
+	};
+
+	// Reflect pipeline progress onto the placeholder tiles. Progress is
+	// reported 0-100; hold at 99 until the model is marked done so the tile
+	// does not appear finished before the sync completes.
+	wp.data.subscribe( function () {
+		if ( progressModels.size === 0 ) {
+			return;
+		}
+
+		var items = wp.data.select( uploadStore ).getItems();
+		items.forEach( function ( item ) {
+			if ( ! item.sourceFile ) {
+				return;
+			}
+
+			var model = progressModels.get( fileKey( item.sourceFile ) );
+			if ( ! model ) {
+				return;
+			}
+
+			if ( typeof item.progress === 'number' ) {
+				model.set( {
+					percent: Math.min( 99, Math.round( item.progress ) ),
+				} );
+			}
+		} );
+	} );
+} )();

--- a/js/media-library-upload.js
+++ b/js/media-library-upload.js
@@ -127,7 +127,7 @@
 					args.onError(
 						error instanceof Error
 							? error
-							: new Error( String( error ) )
+							: new Error( error && error.message ? error.message : String( error ) )
 					);
 				}
 			} );

--- a/js/media-library-upload.js
+++ b/js/media-library-upload.js
@@ -404,6 +404,19 @@
 		);
 	};
 
+	// Warn before leaving while pipeline uploads are in flight: thumbnails
+	// that have not been sideloaded yet are lost and the attachment is left
+	// unfinalized, unlike classic uploads that complete server-side once
+	// the bytes arrive. Models stay in the progress map from interception
+	// until success or error, so the map doubles as the in-flight signal.
+	window.addEventListener( 'beforeunload', function ( event ) {
+		if ( progressModels.size > 0 ) {
+			event.preventDefault();
+			// Some Chromium versions only show the prompt for returnValue.
+			event.returnValue = '';
+		}
+	} );
+
 	// Reflect pipeline progress onto the placeholder tiles. Progress is
 	// reported 0-100; hold at 99 until the model is marked done so the tile
 	// does not appear finished before the sync completes.

--- a/js/media-new-upload.js
+++ b/js/media-new-upload.js
@@ -1,0 +1,377 @@
+/**
+ * Routes "Add New Media File" uploads through the client-side media pipeline.
+ *
+ * On wp-admin/media-new.php WordPress uploads via a raw plupload.Uploader
+ * (created by plupload-handlers) posting to async-upload.php. When the
+ * browser is cross-origin isolated and supports the client-side pipeline,
+ * this script intercepts the uploader's FilesAdded handler and routes files
+ * through @wordpress/upload-media instead: the original image is uploaded
+ * via the REST API and thumbnails are generated in the browser (wasm-vips),
+ * then sideloaded and finalized.
+ *
+ * The screen's existing UI helpers from plupload-handlers are reused:
+ * fileQueued() builds the progress item, uploadSuccess() renders the
+ * finished attachment row (via the async-upload.php markup endpoint),
+ * itemAjaxError() surfaces per-file errors, and uploadComplete() runs when
+ * the queue drains. The screen therefore looks and behaves unchanged.
+ *
+ * When client-side support is unavailable the script cleanly no-ops and
+ * the classic plupload flow is left untouched.
+ */
+
+/* global wp, plupload, uploader, fileQueued, uploadStart, uploadSuccess, itemAjaxError, uploadComplete */
+
+( function () {
+	// Guard against double execution (e.g. duplicate enqueues).
+	if ( window.__csmeMediaNewUpload ) {
+		return;
+	}
+
+	// Require every dependency the integration relies on.
+	if (
+		typeof wp === 'undefined' ||
+		typeof plupload === 'undefined' ||
+		typeof jQuery === 'undefined' ||
+		! wp.uploadMedia ||
+		! wp.mediaUtils ||
+		! wp.data ||
+		! wp.element ||
+		! wp.apiFetch
+	) {
+		return;
+	}
+
+	// Bail unless the browser actually supports client-side processing. This
+	// is the clean no-op: when the isolation headers did not land, classic
+	// plupload keeps handling uploads.
+	if (
+		! wp.uploadMedia.detectClientSideMediaSupport ||
+		! wp.uploadMedia.detectClientSideMediaSupport().supported
+	) {
+		return;
+	}
+
+	window.__csmeMediaNewUpload = true;
+
+	var __ = wp.i18n.__;
+	var settings = window.csmeMediaNewSettings || {};
+	var uploadStore = wp.uploadMedia.store;
+
+	// Number of pipeline uploads currently in flight, used for the
+	// beforeunload guard and to fire uploadComplete() when the queue drains.
+	var inFlightCount = 0;
+
+	// Map from a file identity key to the plupload file IDs sharing it
+	// (an array: concurrent uploads of an identical file share a key), used
+	// to reflect pipeline progress onto the screen's progress bars.
+	var progressIds = new Map();
+
+	/**
+	 * Builds a stable identity key for a File.
+	 *
+	 * The queue item's `sourceFile` is a clone of the original file, so it
+	 * cannot be matched by reference. The clone preserves name, size, and
+	 * last-modified time, which together identify a file within one session.
+	 * Two in-flight uploads of the same file collide on this key, so keys
+	 * map to arrays of IDs and progress is mirrored to all of them.
+	 *
+	 * @param {File} file The file to key.
+	 * @return {string} Identity key.
+	 */
+	function fileKey( file ) {
+		return file.name + '::' + file.size + '::' + file.lastModified;
+	}
+
+	/**
+	 * Recursively appends data to a FormData object, supporting nested objects.
+	 *
+	 * Mirrors flattenFormData() in @wordpress/media-utils.
+	 *
+	 * @param {FormData}      formData The form data to append to.
+	 * @param {string}        key      The key to append under.
+	 * @param {string|Object} data     The value to append.
+	 */
+	function flattenFormData( formData, key, data ) {
+		if (
+			data !== null &&
+			typeof data === 'object' &&
+			Object.getPrototypeOf( data ) === Object.prototype
+		) {
+			Object.keys( data ).forEach( function ( name ) {
+				flattenFormData( formData, key + '[' + name + ']', data[ name ] );
+			} );
+		} else if ( data !== undefined ) {
+			formData.append( key, String( data ) );
+		}
+	}
+
+	/**
+	 * Sideloads a client-generated thumbnail to an existing attachment.
+	 *
+	 * Reimplements the private sideloadMedia() helper from
+	 * @wordpress/media-utils as a thin apiFetch wrapper.
+	 *
+	 * @param {Object} args The sideload arguments.
+	 */
+	function csmeMediaSideload( args ) {
+		var file = args.file;
+		var additionalData = args.additionalData || {};
+
+		var data = new FormData();
+		data.append( 'file', file, file.name || file.type.replace( '/', '.' ) );
+		Object.keys( additionalData ).forEach( function ( key ) {
+			flattenFormData( data, key, additionalData[ key ] );
+		} );
+
+		wp.apiFetch( {
+			path: '/wp/v2/media/' + args.attachmentId + '/sideload',
+			body: data,
+			method: 'POST',
+			signal: args.signal,
+		} )
+			.then( function ( subSize ) {
+				if ( args.onSuccess ) {
+					args.onSuccess( subSize );
+				}
+			} )
+			.catch( function ( error ) {
+				if ( args.onError ) {
+					args.onError(
+						error instanceof Error
+							? error
+							: new Error( error && error.message ? error.message : String( error ) )
+					);
+				}
+			} );
+	}
+
+	/**
+	 * Finalizes an upload once all client-side processing is complete.
+	 *
+	 * Reimplements the private mediaFinalize() helper. The returned
+	 * attachment is load-bearing: it carries the post-finalize (scaled)
+	 * URL used for srcset.
+	 *
+	 * @param {number} id       The parent attachment ID.
+	 * @param {Array}  subSizes Accumulated sub-size data.
+	 * @return {Promise} Resolves with the transformed attachment.
+	 */
+	function csmeMediaFinalize( id, subSizes ) {
+		return wp
+			.apiFetch( {
+				path: '/wp/v2/media/' + id + '/finalize',
+				method: 'POST',
+				data: { sub_sizes: subSizes || [] },
+			} )
+			.then( function ( response ) {
+				return response
+					? wp.mediaUtils.transformAttachment( response )
+					: undefined;
+			} );
+	}
+
+	// Configure the default-registry upload-media store once. Rendering the
+	// provider with useSubRegistry: false wires the settings into the store
+	// that wp.data.dispatch/select address (the block editor does the same).
+	var pipelineSettings = {
+		mediaUpload: wp.mediaUtils.uploadMedia,
+		mediaSideload: csmeMediaSideload,
+		mediaFinalize: csmeMediaFinalize,
+		maxUploadFileSize: settings.maxUploadFileSize,
+		allowedMimeTypes: settings.allowedMimeTypes,
+		allImageSizes: settings.allImageSizes,
+		bigImageSizeThreshold: settings.bigImageSizeThreshold,
+		imageStripMeta: settings.imageStripMeta,
+		imageMaxBitDepth: settings.imageMaxBitDepth,
+	};
+
+	wp.element
+		.createRoot( document.createElement( 'div' ) )
+		.render(
+			wp.element.createElement( wp.uploadMedia.MediaUploadProvider, {
+				settings: pipelineSettings,
+				useSubRegistry: false,
+			} )
+		);
+
+	/**
+	 * Removes a plupload file ID from the progress map.
+	 *
+	 * @param {string} fileId The plupload file ID to stop tracking.
+	 */
+	function stopTrackingProgress( fileId ) {
+		progressIds.forEach( function ( ids, key ) {
+			var index = ids.indexOf( fileId );
+			if ( index !== -1 ) {
+				ids.splice( index, 1 );
+			}
+			if ( ids.length === 0 ) {
+				progressIds.delete( key );
+			}
+		} );
+	}
+
+	/**
+	 * Marks one pipeline upload as finished, firing uploadComplete() when
+	 * the queue drains.
+	 *
+	 * The built-in UploadComplete binding never fires for pipeline uploads
+	 * because every file is removed from plupload before its queue starts.
+	 */
+	function finishUpload() {
+		inFlightCount--;
+		if ( inFlightCount === 0 ) {
+			uploadComplete();
+		}
+	}
+
+	/**
+	 * Intercepts files added to the plupload uploader.
+	 *
+	 * Returns undefined (not false) when the store is not yet configured so
+	 * the built-in handler runs and uploads server-side - a degradation, never
+	 * data loss. Otherwise builds the screen's progress items, routes each
+	 * file through the pipeline, and returns false to suppress the built-in
+	 * handler (which would otherwise queue and start a classic upload).
+	 *
+	 * @param {Object} up    The plupload uploader instance.
+	 * @param {Array}  files Files added to the queue.
+	 * @return {boolean|undefined} False to suppress the built-in handler.
+	 */
+	function handleFilesAdded( up, files ) {
+		var storeSettings = wp.data.select( uploadStore ).getSettings();
+
+		// Safety valve: if settings never landed, defer to classic plupload.
+		if ( ! storeSettings || ! storeSettings.mediaUpload ) {
+			return;
+		}
+
+		// Parity with the built-in handler: clear stale queue errors and run
+		// the shared upload-start housekeeping.
+		jQuery( '#media-upload-error' ).empty();
+		uploadStart();
+
+		files.forEach( function ( file ) {
+			// Ignore failed uploads.
+			if ( plupload.FAILED === file.status ) {
+				return;
+			}
+
+			// Build the screen's progress item for this file.
+			fileQueued( file );
+
+			var nativeFile = file.getNative();
+			var key = fileKey( nativeFile );
+			var ids = progressIds.get( key );
+			if ( ids ) {
+				ids.push( file.id );
+			} else {
+				progressIds.set( key, [ file.id ] );
+			}
+
+			// Remove the file from plupload so it is not uploaded twice.
+			up.removeFile( file );
+
+			inFlightCount++;
+
+			wp.data.dispatch( uploadStore ).addItems( {
+				files: [ nativeFile ],
+				onSuccess: function ( attachments ) {
+					// uploadSuccess() renders the finished attachment row via
+					// the existing async-upload.php markup endpoint; the
+					// server normally returns the ID as a string.
+					uploadSuccess( file, String( attachments[ 0 ].id ) );
+					stopTrackingProgress( file.id );
+					finishUpload();
+				},
+				onError: function ( error ) {
+					var message =
+						( wp.uploadMedia.getErrorMessage &&
+							wp.uploadMedia.getErrorMessage( error ) ) ||
+						( error && error.message ) ||
+						__(
+							'An error occurred while uploading the file.',
+							'client-side-media-everywhere'
+						);
+
+					itemAjaxError( file.id, message );
+					stopTrackingProgress( file.id );
+					finishUpload();
+				},
+			} );
+		} );
+
+		up.refresh();
+
+		return false;
+	}
+
+	jQuery( function () {
+		// plupload-handlers creates the global `uploader` in its own ready
+		// callback, which runs before this one: ready callbacks run in
+		// registration order and this script loads after plupload-handlers.
+		// The global stays undefined when wpUploaderInit is missing (the
+		// html-uploader fallback), in which case there is nothing to bind.
+		if (
+			typeof uploader !== 'object' ||
+			! uploader ||
+			uploader.__csmeMediaNewBound
+		) {
+			return;
+		}
+		uploader.__csmeMediaNewBound = true;
+
+		// plupload sorts handlers by priority (descending) and a `false`
+		// return breaks the chain, so priority 100 runs before and suppresses
+		// the built-in FilesAdded handler.
+		uploader.bind(
+			'FilesAdded',
+			function ( up, files ) {
+				return handleFilesAdded( up, files );
+			},
+			null,
+			100
+		);
+	} );
+
+	// Warn before leaving while pipeline uploads are in flight: thumbnails
+	// that have not been sideloaded yet are lost and the attachment is left
+	// unfinalized, unlike classic uploads that complete server-side once
+	// the bytes arrive.
+	window.addEventListener( 'beforeunload', function ( event ) {
+		if ( inFlightCount > 0 ) {
+			event.preventDefault();
+			// Some Chromium versions only show the prompt for returnValue.
+			event.returnValue = '';
+		}
+	} );
+
+	// Reflect pipeline progress onto the screen's progress bars. Progress is
+	// reported 0-100; hold at 99 until the finished row is rendered so the
+	// bar does not appear done before the markup fetch completes. The bar is
+	// 200px wide at 100%, matching uploadProgress() in plupload-handlers.
+	wp.data.subscribe( function () {
+		if ( progressIds.size === 0 ) {
+			return;
+		}
+
+		var items = wp.data.select( uploadStore ).getItems();
+		items.forEach( function ( item ) {
+			if ( ! item.sourceFile || typeof item.progress !== 'number' ) {
+				return;
+			}
+
+			var ids = progressIds.get( fileKey( item.sourceFile ) );
+			if ( ! ids ) {
+				return;
+			}
+
+			var percent = Math.min( 99, Math.round( item.progress ) );
+			ids.forEach( function ( id ) {
+				var mediaItem = jQuery( '#media-item-' + id );
+				mediaItem.find( '.bar' ).width( 2 * percent );
+				mediaItem.find( '.percent' ).html( percent + '%' );
+			} );
+		} );
+	} );
+} )();

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,6 +9,10 @@
 		<testsuite name="Client-Side Media Everywhere">
 			<directory suffix=".php">tests/</directory>
 			<exclude>tests/bootstrap.php</exclude>
+			<!-- Playwright fixtures, not PHPUnit tests. They are loaded as
+			     real mu-plugins under wp-env, so scanning them here would
+			     redeclare their functions. -->
+			<exclude>tests/e2e</exclude>
 		</testsuite>
 	</testsuites>
 

--- a/readme.txt
+++ b/readme.txt
@@ -46,7 +46,7 @@ Check that your site is served over HTTPS (or localhost). Client-side media proc
 
 = Do I need this plugin on Chrome? =
 
-No. Chrome 137+ uses Document-Isolation-Policy, which is handled by WordPress core / Gutenberg. This plugin only activates on browsers that do not support DIP.
+Not in the block editor. Chrome 137+ uses Document-Isolation-Policy for the block editor, which is handled by WordPress core / Gutenberg. However, the Media Library grid (Media > Library) still requires this plugin on Chrome 137+ to initiate Document-Isolation-Policy handling on upload.php, which core does not do. Outside the Media Library grid, this plugin only activates on browsers that do not support DIP.
 
 = Will this break my site? =
 

--- a/readme.txt
+++ b/readme.txt
@@ -24,7 +24,8 @@ This plugin restores support for Firefox and Safari by sending the older COEP/CO
 * Adds `crossorigin="anonymous"` attributes to cross-origin resources.
 * Adds `credentialless` attribute to iframes so they continue working under COEP.
 * Filters embed previews for providers that do not support credentialless iframes (Facebook, SmugMug).
-* Extends client-side media processing to the Media Library grid (Media > Library), which core processes server-side. On the grid screen the plugin restores cross-origin isolation - including sending the Document-Isolation-Policy header on Chrome 137+, which core does not send there - and routes uploads through the browser pipeline (REST upload, client-side thumbnails, sideload, finalize), falling back to the classic upload when unsupported. Only grid mode is covered; list mode and the Add New Media File screen upload server-side.
+* Extends client-side media processing to the Media Library (Media > Library) and the Add New Media File screen (Media > Add New Media File), which core processes server-side. On both screens the plugin restores cross-origin isolation - including sending the Document-Isolation-Policy header on Chrome 137+, which core does not send there - and routes uploads through the browser pipeline (REST upload, client-side thumbnails, sideload, finalize), falling back to the classic upload when unsupported. The Media Library's list mode uploads via the Add New Media File screen, so both views are covered.
+* Warns before leaving the page while a pipeline upload is in flight, since browser-generated thumbnails that have not been sideloaded yet would be lost.
 
 **Requirements:**
 
@@ -46,15 +47,15 @@ Check that your site is served over HTTPS (or localhost). Client-side media proc
 
 = Do I need this plugin on Chrome? =
 
-Not in the block editor. Chrome 137+ uses Document-Isolation-Policy for the block editor, which is handled by WordPress core / Gutenberg. However, the Media Library grid (Media > Library) still requires this plugin on Chrome 137+ to initiate Document-Isolation-Policy handling on upload.php, which core does not do. Outside the Media Library grid, this plugin only activates on browsers that do not support DIP.
+Not in the block editor. Chrome 137+ uses Document-Isolation-Policy for the block editor, which is handled by WordPress core / Gutenberg. However, the Media Library (Media > Library) and the Add New Media File screen still require this plugin on Chrome 137+ to initiate Document-Isolation-Policy handling on upload.php and media-new.php, which core does not do. Outside those media screens, this plugin only activates on browsers that do not support DIP.
 
 = Will this break my site? =
 
-The isolation headers are only sent on the block editor admin pages and the Media Library grid screen, not on the front-end. Some third-party plugins that use iframes in the editor may be affected. If you experience issues, you can deactivate the plugin.
+The isolation headers are only sent on the block editor admin pages and the media upload screens (the Media Library grid and Add New Media File), not on the front-end. Some third-party plugins that use iframes in the editor may be affected. If you experience issues, you can deactivate the plugin.
 
 = Does client-side processing work in the Media Library? =
 
-Yes. On the Media Library grid (Media > Library) this plugin routes uploads through the browser pipeline, the same way the block editor does, on browsers that support it. List mode and the separate Add New Media File screen still upload server-side. When client-side processing is unavailable, grid uploads fall back to the classic server-side upload automatically.
+Yes. On the Media Library grid (Media > Library) and the Add New Media File screen this plugin routes uploads through the browser pipeline, the same way the block editor does, on browsers that support it. List mode uploads go through the Add New Media File screen, so both Media Library views are covered. When client-side processing is unavailable, uploads fall back to the classic server-side upload automatically.
 
 = Can I disable the COEP/COOP behavior? =
 

--- a/readme.txt
+++ b/readme.txt
@@ -24,6 +24,7 @@ This plugin restores support for Firefox and Safari by sending the older COEP/CO
 * Adds `crossorigin="anonymous"` attributes to cross-origin resources.
 * Adds `credentialless` attribute to iframes so they continue working under COEP.
 * Filters embed previews for providers that do not support credentialless iframes (Facebook, SmugMug).
+* Extends client-side media processing to the Media Library grid (Media > Library), which core processes server-side. On the grid screen the plugin restores cross-origin isolation - including sending the Document-Isolation-Policy header on Chrome 137+, which core does not send there - and routes uploads through the browser pipeline (REST upload, client-side thumbnails, sideload, finalize), falling back to the classic upload when unsupported. Only grid mode is covered; list mode and the Add New Media File screen upload server-side.
 
 **Requirements:**
 
@@ -49,7 +50,11 @@ No. Chrome 137+ uses Document-Isolation-Policy, which is handled by WordPress co
 
 = Will this break my site? =
 
-The COEP/COOP headers are only sent on block editor admin pages, not on the front-end. Some third-party plugins that use iframes in the editor may be affected. If you experience issues, you can deactivate the plugin.
+The isolation headers are only sent on the block editor admin pages and the Media Library grid screen, not on the front-end. Some third-party plugins that use iframes in the editor may be affected. If you experience issues, you can deactivate the plugin.
+
+= Does client-side processing work in the Media Library? =
+
+Yes. On the Media Library grid (Media > Library) this plugin routes uploads through the browser pipeline, the same way the block editor does, on browsers that support it. List mode and the separate Add New Media File screen still upload server-side. When client-side processing is unavailable, grid uploads fall back to the classic server-side upload automatically.
 
 = Can I disable the COEP/COOP behavior? =
 

--- a/tests/Test_Enqueue_Scripts.php
+++ b/tests/Test_Enqueue_Scripts.php
@@ -12,6 +12,7 @@ class Test_Enqueue_Scripts extends WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		remove_all_filters( 'csme_use_coep_coop' );
+		unset( $_GET['mode'] );
 		wp_dequeue_script( 'csme-cross-origin-isolation-coep' );
 		wp_deregister_script( 'csme-cross-origin-isolation-coep' );
 		parent::tear_down();
@@ -116,5 +117,54 @@ class Test_Enqueue_Scripts extends WP_UnitTestCase {
 		csme_enqueue_scripts( 'widgets.php' );
 
 		$this->assertTrue( wp_script_is( 'csme-cross-origin-isolation-coep', 'enqueued' ) );
+	}
+
+	/**
+	 * Script is enqueued on upload.php in grid mode.
+	 */
+	public function test_script_enqueued_on_upload_php_grid() {
+		add_filter( 'csme_use_coep_coop', '__return_true' );
+		$_GET['mode'] = 'grid';
+
+		csme_enqueue_scripts( 'upload.php' );
+
+		$this->assertTrue( wp_script_is( 'csme-cross-origin-isolation-coep', 'enqueued' ) );
+	}
+
+	/**
+	 * Script is not enqueued on upload.php in list mode.
+	 */
+	public function test_script_not_enqueued_on_upload_php_list() {
+		add_filter( 'csme_use_coep_coop', '__return_true' );
+		$_GET['mode'] = 'list';
+
+		csme_enqueue_scripts( 'upload.php' );
+
+		$this->assertFalse( wp_script_is( 'csme-cross-origin-isolation-coep', 'enqueued' ) );
+	}
+
+	/**
+	 * On upload.php the observer script does not depend on wp-block-editor.
+	 */
+	public function test_upload_php_deps_exclude_block_editor() {
+		add_filter( 'csme_use_coep_coop', '__return_true' );
+		$_GET['mode'] = 'grid';
+
+		csme_enqueue_scripts( 'upload.php' );
+
+		$script = wp_scripts()->registered['csme-cross-origin-isolation-coep'];
+		$this->assertNotContains( 'wp-block-editor', $script->deps );
+	}
+
+	/**
+	 * On block editor screens the observer script still depends on wp-block-editor.
+	 */
+	public function test_editor_deps_include_block_editor() {
+		add_filter( 'csme_use_coep_coop', '__return_true' );
+
+		csme_enqueue_scripts( 'post.php' );
+
+		$script = wp_scripts()->registered['csme-cross-origin-isolation-coep'];
+		$this->assertContains( 'wp-block-editor', $script->deps );
 	}
 }

--- a/tests/Test_Enqueue_Scripts.php
+++ b/tests/Test_Enqueue_Scripts.php
@@ -8,6 +8,26 @@
 class Test_Enqueue_Scripts extends WP_UnitTestCase {
 
 	/**
+	 * Preserved state for cleanup.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private $preserved_state = array();
+
+	/**
+	 * Set up before each test: register a stub upload-media script.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// Preserve existing wp-upload-media registration if any.
+		$this->preserved_state['wp_upload_media'] = wp_scripts()->query( 'wp-upload-media', 'registered' );
+
+		// The Media Library enqueue is gated on the upload-media package.
+		wp_register_script( 'wp-upload-media', 'https://example.org/upload-media.js', array(), '1.0', true );
+	}
+
+	/**
 	 * Tear down after each test.
 	 */
 	public function tear_down() {
@@ -15,6 +35,20 @@ class Test_Enqueue_Scripts extends WP_UnitTestCase {
 		unset( $_GET['mode'] );
 		wp_dequeue_script( 'csme-cross-origin-isolation-coep' );
 		wp_deregister_script( 'csme-cross-origin-isolation-coep' );
+
+		// Restore pre-existing wp-upload-media registration or deregister.
+		wp_deregister_script( 'wp-upload-media' );
+		if ( false !== $this->preserved_state['wp_upload_media'] ) {
+			$script = $this->preserved_state['wp_upload_media'];
+			wp_register_script(
+				'wp-upload-media',
+				$script->src,
+				$script->deps,
+				$script->ver,
+				$script->args
+			);
+		}
+
 		parent::tear_down();
 	}
 
@@ -137,6 +171,23 @@ class Test_Enqueue_Scripts extends WP_UnitTestCase {
 	public function test_script_not_enqueued_on_upload_php_list() {
 		add_filter( 'csme_use_coep_coop', '__return_true' );
 		$_GET['mode'] = 'list';
+
+		csme_enqueue_scripts( 'upload.php' );
+
+		$this->assertFalse( wp_script_is( 'csme-cross-origin-isolation-coep', 'enqueued' ) );
+	}
+
+	/**
+	 * Script is not enqueued on upload.php without the upload-media package.
+	 *
+	 * No isolation headers are sent without it, so the observer script
+	 * would be dead weight.
+	 */
+	public function test_script_not_enqueued_on_upload_php_without_upload_media() {
+		add_filter( 'csme_use_coep_coop', '__return_true' );
+		$_GET['mode'] = 'grid';
+
+		wp_deregister_script( 'wp-upload-media' );
 
 		csme_enqueue_scripts( 'upload.php' );
 

--- a/tests/Test_Media_Library_Enqueue.php
+++ b/tests/Test_Media_Library_Enqueue.php
@@ -8,13 +8,27 @@
 class Test_Media_Library_Enqueue extends WP_UnitTestCase {
 
 	/**
+	 * Preserved state for cleanup.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private $preserved_state = array();
+
+	/**
 	 * Set up before each test: register a stub upload-media script.
 	 */
 	public function set_up() {
 		parent::set_up();
+
+		// Preserve existing wp-upload-media registration if any.
+		$this->preserved_state['wp_upload_media'] = wp_scripts()->query( 'wp-upload-media', 'registered' );
+
 		// The integration requires core's (or Gutenberg's) upload-media
 		// package to be registered. Register a stub for the test.
 		wp_register_script( 'wp-upload-media', 'https://example.org/upload-media.js', array(), '1.0', true );
+
+		// Register a test-specific filter for big_image_size_threshold.
+		add_filter( 'big_image_size_threshold', array( $this, 'test_big_image_size_threshold_callback' ), 999 );
 	}
 
 	/**
@@ -22,11 +36,36 @@ class Test_Media_Library_Enqueue extends WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		unset( $_GET['mode'] );
-		remove_all_filters( 'big_image_size_threshold' );
+
+		// Remove only the test's own filter.
+		remove_filter( 'big_image_size_threshold', array( $this, 'test_big_image_size_threshold_callback' ), 999 );
+
 		wp_dequeue_script( 'csme-media-library-upload' );
 		wp_deregister_script( 'csme-media-library-upload' );
+
+		// Restore pre-existing wp-upload-media registration or deregister.
 		wp_deregister_script( 'wp-upload-media' );
+		if ( false !== $this->preserved_state['wp_upload_media'] ) {
+			$script = $this->preserved_state['wp_upload_media'];
+			wp_register_script(
+				'wp-upload-media',
+				$script->src,
+				$script->deps,
+				$script->ver,
+				$script->args
+			);
+		}
+
 		parent::tear_down();
+	}
+
+	/**
+	 * Test-owned callback for big_image_size_threshold filter.
+	 *
+	 * @return int|false Pass-through for the filtered value.
+	 */
+	public function test_big_image_size_threshold_callback( $threshold ) {
+		return $threshold;
 	}
 
 	/**

--- a/tests/Test_Media_Library_Enqueue.php
+++ b/tests/Test_Media_Library_Enqueue.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * Tests for csme_enqueue_media_library_scripts() and settings.
+ *
+ * @package ClientSideMediaEverywhere
+ */
+
+class Test_Media_Library_Enqueue extends WP_UnitTestCase {
+
+	/**
+	 * Set up before each test: register a stub upload-media script.
+	 */
+	public function set_up() {
+		parent::set_up();
+		// The integration requires core's (or Gutenberg's) upload-media
+		// package to be registered. Register a stub for the test.
+		wp_register_script( 'wp-upload-media', 'https://example.org/upload-media.js', array(), '1.0', true );
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down() {
+		unset( $_GET['mode'] );
+		remove_all_filters( 'big_image_size_threshold' );
+		wp_dequeue_script( 'csme-media-library-upload' );
+		wp_deregister_script( 'csme-media-library-upload' );
+		wp_deregister_script( 'wp-upload-media' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Script is enqueued on upload.php in grid mode.
+	 */
+	public function test_script_enqueued_on_upload_php_grid() {
+		$_GET['mode'] = 'grid';
+
+		csme_enqueue_media_library_scripts( 'upload.php' );
+
+		$this->assertTrue( wp_script_is( 'csme-media-library-upload', 'enqueued' ) );
+	}
+
+	/**
+	 * Script is not enqueued on upload.php in list mode.
+	 */
+	public function test_script_not_enqueued_in_list_mode() {
+		$_GET['mode'] = 'list';
+
+		csme_enqueue_media_library_scripts( 'upload.php' );
+
+		$this->assertFalse( wp_script_is( 'csme-media-library-upload', 'enqueued' ) );
+	}
+
+	/**
+	 * Script is not enqueued on other admin pages.
+	 */
+	public function test_script_not_enqueued_on_other_pages() {
+		$_GET['mode'] = 'grid';
+
+		csme_enqueue_media_library_scripts( 'options-general.php' );
+
+		$this->assertFalse( wp_script_is( 'csme-media-library-upload', 'enqueued' ) );
+	}
+
+	/**
+	 * Script is not enqueued when the upload-media package is not registered.
+	 */
+	public function test_script_not_enqueued_without_upload_media() {
+		$_GET['mode'] = 'grid';
+		wp_deregister_script( 'wp-upload-media' );
+
+		csme_enqueue_media_library_scripts( 'upload.php' );
+
+		$this->assertFalse( wp_script_is( 'csme-media-library-upload', 'enqueued' ) );
+	}
+
+	/**
+	 * The script depends on media-views and wp-upload-media, not wp-block-editor.
+	 */
+	public function test_dependencies() {
+		$_GET['mode'] = 'grid';
+
+		csme_enqueue_media_library_scripts( 'upload.php' );
+
+		$script = wp_scripts()->registered['csme-media-library-upload'];
+		$this->assertContains( 'media-views', $script->deps );
+		$this->assertContains( 'wp-upload-media', $script->deps );
+		$this->assertNotContains( 'wp-block-editor', $script->deps );
+	}
+
+	/**
+	 * The inline settings expose all six pipeline keys.
+	 */
+	public function test_inline_settings_expose_all_keys() {
+		$_GET['mode'] = 'grid';
+
+		csme_enqueue_media_library_scripts( 'upload.php' );
+
+		$before = wp_scripts()->get_data( 'csme-media-library-upload', 'before' );
+		$inline = implode( "\n", (array) $before );
+
+		$this->assertStringContainsString( 'window.csmeMediaLibrarySettings', $inline );
+
+		foreach ( array(
+			'maxUploadFileSize',
+			'allowedMimeTypes',
+			'allImageSizes',
+			'bigImageSizeThreshold',
+			'imageStripMeta',
+			'imageMaxBitDepth',
+		) as $key ) {
+			$this->assertStringContainsString( $key, $inline );
+		}
+	}
+
+	/**
+	 * The big-image threshold in the settings responds to its filter.
+	 */
+	public function test_big_image_size_threshold_filter() {
+		add_filter(
+			'big_image_size_threshold',
+			static function () {
+				return 4096;
+			}
+		);
+
+		$settings = csme_get_media_library_settings();
+
+		$this->assertSame( 4096, $settings['bigImageSizeThreshold'] );
+	}
+
+	/**
+	 * The settings array contains the expected value types.
+	 */
+	public function test_settings_value_types() {
+		$settings = csme_get_media_library_settings();
+
+		$this->assertIsInt( $settings['maxUploadFileSize'] );
+		$this->assertIsArray( $settings['allowedMimeTypes'] );
+		$this->assertIsArray( $settings['allImageSizes'] );
+		$this->assertIsInt( $settings['bigImageSizeThreshold'] );
+		$this->assertIsBool( $settings['imageStripMeta'] );
+		$this->assertIsInt( $settings['imageMaxBitDepth'] );
+	}
+}

--- a/tests/Test_Media_Library_Enqueue.php
+++ b/tests/Test_Media_Library_Enqueue.php
@@ -26,9 +26,6 @@ class Test_Media_Library_Enqueue extends WP_UnitTestCase {
 		// The integration requires core's (or Gutenberg's) upload-media
 		// package to be registered. Register a stub for the test.
 		wp_register_script( 'wp-upload-media', 'https://example.org/upload-media.js', array(), '1.0', true );
-
-		// Register a test-specific filter for big_image_size_threshold.
-		add_filter( 'big_image_size_threshold', array( $this, 'test_big_image_size_threshold_callback' ), 999 );
 	}
 
 	/**
@@ -36,10 +33,6 @@ class Test_Media_Library_Enqueue extends WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		unset( $_GET['mode'] );
-
-		// Remove only the test's own filter.
-		remove_filter( 'big_image_size_threshold', array( $this, 'test_big_image_size_threshold_callback' ), 999 );
-
 		wp_dequeue_script( 'csme-media-library-upload' );
 		wp_deregister_script( 'csme-media-library-upload' );
 
@@ -57,15 +50,6 @@ class Test_Media_Library_Enqueue extends WP_UnitTestCase {
 		}
 
 		parent::tear_down();
-	}
-
-	/**
-	 * Test-owned callback for big_image_size_threshold filter.
-	 *
-	 * @return int|false Pass-through for the filtered value.
-	 */
-	public function test_big_image_size_threshold_callback( $threshold ) {
-		return $threshold;
 	}
 
 	/**

--- a/tests/Test_Media_Library_Isolation.php
+++ b/tests/Test_Media_Library_Isolation.php
@@ -13,6 +13,7 @@ class Test_Media_Library_Isolation extends WP_UnitTestCase {
 	public function tear_down() {
 		remove_all_filters( 'csme_use_coep_coop' );
 		unset( $_GET['mode'] );
+		unset( $_SERVER['HTTP_USER_AGENT'] );
 		wp_set_current_user( 0 );
 		parent::tear_down();
 	}
@@ -151,14 +152,22 @@ class Test_Media_Library_Isolation extends WP_UnitTestCase {
 		// Force the DIP path: COEP/COOP disabled and a modern Chromium version.
 		add_filter( 'csme_use_coep_coop', '__return_false' );
 
-		if ( ! function_exists( 'wp_get_chromium_major_version' ) ) {
-			function wp_get_chromium_major_version() {
-				return 140;
-			}
-		}
+		/*
+		 * Core's real wp_start_cross_origin_isolation_output_buffer() (WP 7.1+)
+		 * reads the User-Agent and only starts the buffer for Chromium 137+,
+		 * so provide one rather than stubbing the version check.
+		 */
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36';
+
 		if ( ! function_exists( 'wp_start_cross_origin_isolation_output_buffer' ) ) {
+			// Environments predating WP 7.1: stub the buffer function the
+			// plugin dispatches to, honoring the same Chromium check.
 			function wp_start_cross_origin_isolation_output_buffer() {
-				ob_start();
+				if ( isset( $_SERVER['HTTP_USER_AGENT'] )
+					&& preg_match( '#Chrome/(\d+)#', $_SERVER['HTTP_USER_AGENT'], $matches )
+					&& (int) $matches[1] >= 137 ) {
+					ob_start();
+				}
 			}
 		}
 

--- a/tests/Test_Media_Library_Isolation.php
+++ b/tests/Test_Media_Library_Isolation.php
@@ -8,6 +8,26 @@
 class Test_Media_Library_Isolation extends WP_UnitTestCase {
 
 	/**
+	 * Preserved state for cleanup.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private $preserved_state = array();
+
+	/**
+	 * Set up before each test: register a stub upload-media script.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// Preserve existing wp-upload-media registration if any.
+		$this->preserved_state['wp_upload_media'] = wp_scripts()->query( 'wp-upload-media', 'registered' );
+
+		// Isolation is gated on the upload-media package being registered.
+		wp_register_script( 'wp-upload-media', 'https://example.org/upload-media.js', array(), '1.0', true );
+	}
+
+	/**
 	 * Tear down after each test.
 	 */
 	public function tear_down() {
@@ -15,6 +35,20 @@ class Test_Media_Library_Isolation extends WP_UnitTestCase {
 		unset( $_GET['mode'] );
 		unset( $_SERVER['HTTP_USER_AGENT'] );
 		wp_set_current_user( 0 );
+
+		// Restore pre-existing wp-upload-media registration or deregister.
+		wp_deregister_script( 'wp-upload-media' );
+		if ( false !== $this->preserved_state['wp_upload_media'] ) {
+			$script = $this->preserved_state['wp_upload_media'];
+			wp_register_script(
+				'wp-upload-media',
+				$script->src,
+				$script->deps,
+				$script->ver,
+				$script->args
+			);
+		}
+
 		parent::tear_down();
 	}
 
@@ -110,6 +144,28 @@ class Test_Media_Library_Isolation extends WP_UnitTestCase {
 
 		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
 		wp_set_current_user( $user_id );
+
+		$ob_level_before = ob_get_level();
+		csme_set_up_media_library_isolation();
+		$ob_level_after = ob_get_level();
+
+		$this->assertSame( $ob_level_before, $ob_level_after );
+	}
+
+	/**
+	 * No output buffer starts when the upload-media package is missing.
+	 *
+	 * Without the package the pipeline cannot run, so no isolation
+	 * headers should be sent either.
+	 */
+	public function test_no_buffer_without_upload_media_package() {
+		add_filter( 'csme_use_coep_coop', '__return_true' );
+		$_GET['mode'] = 'grid';
+
+		$user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $user_id );
+
+		wp_deregister_script( 'wp-upload-media' );
 
 		$ob_level_before = ob_get_level();
 		csme_set_up_media_library_isolation();

--- a/tests/Test_Media_Library_Isolation.php
+++ b/tests/Test_Media_Library_Isolation.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * Tests for csme_set_up_media_library_isolation() and mode resolution.
+ *
+ * @package ClientSideMediaEverywhere
+ */
+
+class Test_Media_Library_Isolation extends WP_UnitTestCase {
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down() {
+		remove_all_filters( 'csme_use_coep_coop' );
+		unset( $_GET['mode'] );
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	/**
+	 * Grid mode is the default when nothing is set.
+	 */
+	public function test_mode_defaults_to_grid() {
+		$this->assertSame( 'grid', csme_get_media_library_mode() );
+	}
+
+	/**
+	 * Mode is read from the query string when valid.
+	 */
+	public function test_mode_from_query_string() {
+		$_GET['mode'] = 'list';
+		$this->assertSame( 'list', csme_get_media_library_mode() );
+	}
+
+	/**
+	 * An invalid query string mode falls back to the default.
+	 */
+	public function test_invalid_query_string_mode_falls_back_to_grid() {
+		$_GET['mode'] = 'bogus';
+		$this->assertSame( 'grid', csme_get_media_library_mode() );
+	}
+
+	/**
+	 * Mode is read from the user option when no query string is present.
+	 */
+	public function test_mode_from_user_option() {
+		$user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $user_id );
+		update_user_option( $user_id, 'media_library_mode', 'list' );
+
+		$this->assertSame( 'list', csme_get_media_library_mode() );
+	}
+
+	/**
+	 * No output buffer starts in list mode.
+	 */
+	public function test_no_buffer_in_list_mode() {
+		add_filter( 'csme_use_coep_coop', '__return_true' );
+		$_GET['mode'] = 'list';
+
+		$user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $user_id );
+
+		$ob_level_before = ob_get_level();
+		csme_set_up_media_library_isolation();
+		$ob_level_after = ob_get_level();
+
+		$this->assertSame( $ob_level_before, $ob_level_after );
+	}
+
+	/**
+	 * No output buffer starts when no user is logged in.
+	 */
+	public function test_no_buffer_when_logged_out() {
+		add_filter( 'csme_use_coep_coop', '__return_true' );
+		$_GET['mode'] = 'grid';
+
+		wp_set_current_user( 0 );
+
+		$ob_level_before = ob_get_level();
+		csme_set_up_media_library_isolation();
+		$ob_level_after = ob_get_level();
+
+		$this->assertSame( $ob_level_before, $ob_level_after );
+	}
+
+	/**
+	 * No output buffer starts when the user cannot upload files.
+	 */
+	public function test_no_buffer_when_user_cannot_upload() {
+		add_filter( 'csme_use_coep_coop', '__return_true' );
+		$_GET['mode'] = 'grid';
+
+		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $user_id );
+
+		$ob_level_before = ob_get_level();
+		csme_set_up_media_library_isolation();
+		$ob_level_after = ob_get_level();
+
+		$this->assertSame( $ob_level_before, $ob_level_after );
+	}
+
+	/**
+	 * The COEP/COOP output buffer starts in grid mode for a capable user.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_starts_coep_coop_buffer_in_grid_mode() {
+		add_filter( 'csme_use_coep_coop', '__return_true' );
+		$_GET['mode'] = 'grid';
+
+		$user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $user_id );
+
+		$ob_level_before = ob_get_level();
+		csme_set_up_media_library_isolation();
+		$ob_level_after = ob_get_level();
+
+		$this->assertSame( $ob_level_before + 1, $ob_level_after );
+
+		while ( ob_get_level() > $ob_level_before ) {
+			ob_end_clean();
+		}
+	}
+
+	/**
+	 * The DIP output buffer starts in grid mode when Chromium 137+ is detected.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_starts_dip_buffer_for_chromium() {
+		// Force the DIP path: COEP/COOP disabled and a modern Chromium version.
+		add_filter( 'csme_use_coep_coop', '__return_false' );
+
+		if ( ! function_exists( 'wp_get_chromium_major_version' ) ) {
+			function wp_get_chromium_major_version() {
+				return 140;
+			}
+		}
+		if ( ! function_exists( 'wp_start_cross_origin_isolation_output_buffer' ) ) {
+			function wp_start_cross_origin_isolation_output_buffer() {
+				ob_start();
+			}
+		}
+
+		$_GET['mode'] = 'grid';
+
+		$user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $user_id );
+
+		$ob_level_before = ob_get_level();
+		csme_set_up_media_library_isolation();
+		$ob_level_after = ob_get_level();
+
+		$this->assertSame( $ob_level_before + 1, $ob_level_after );
+
+		while ( ob_get_level() > $ob_level_before ) {
+			ob_end_clean();
+		}
+	}
+
+	/**
+	 * No buffer starts on the DIP path when core's buffer function is absent.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_no_buffer_when_no_dip_function_available() {
+		add_filter( 'csme_use_coep_coop', '__return_false' );
+		$_GET['mode'] = 'grid';
+
+		$user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $user_id );
+
+		// Neither core nor Gutenberg buffer functions exist in the base test env,
+		// and COEP/COOP is filtered off, so nothing should start a buffer.
+		if ( function_exists( 'wp_start_cross_origin_isolation_output_buffer' )
+			|| function_exists( 'gutenberg_start_cross_origin_isolation_output_buffer' ) ) {
+			$this->markTestSkipped( 'A DIP buffer function is defined in this environment.' );
+		}
+
+		$ob_level_before = ob_get_level();
+		csme_set_up_media_library_isolation();
+		$ob_level_after = ob_get_level();
+
+		$this->assertSame( $ob_level_before, $ob_level_after );
+	}
+}

--- a/tests/Test_Media_Library_Isolation.php
+++ b/tests/Test_Media_Library_Isolation.php
@@ -41,6 +41,22 @@ class Test_Media_Library_Isolation extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A non-canonical query string mode is rejected, matching core.
+	 *
+	 * Core compares the raw value strictly, so `?mode=GRID` falls back
+	 * to the user option rather than being normalized to `grid`.
+	 */
+	public function test_non_canonical_query_string_mode_falls_back_to_user_option() {
+		$user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $user_id );
+		update_user_option( $user_id, 'media_library_mode', 'list' );
+
+		$_GET['mode'] = 'GRID';
+
+		$this->assertSame( 'list', csme_get_media_library_mode() );
+	}
+
+	/**
 	 * Mode is read from the user option when no query string is present.
 	 */
 	public function test_mode_from_user_option() {

--- a/tests/Test_Media_New_Enqueue.php
+++ b/tests/Test_Media_New_Enqueue.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Tests for csme_enqueue_media_new_scripts().
+ *
+ * @package ClientSideMediaEverywhere
+ */
+
+class Test_Media_New_Enqueue extends WP_UnitTestCase {
+
+	/**
+	 * Preserved state for cleanup.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private $preserved_state = array();
+
+	/**
+	 * Set up before each test: register a stub upload-media script.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// Preserve existing wp-upload-media registration if any.
+		$this->preserved_state['wp_upload_media'] = wp_scripts()->query( 'wp-upload-media', 'registered' );
+
+		// The integration requires core's (or Gutenberg's) upload-media
+		// package to be registered. Register a stub for the test.
+		wp_register_script( 'wp-upload-media', 'https://example.org/upload-media.js', array(), '1.0', true );
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down() {
+		wp_dequeue_script( 'csme-media-new-upload' );
+		wp_deregister_script( 'csme-media-new-upload' );
+
+		// Restore pre-existing wp-upload-media registration or deregister.
+		wp_deregister_script( 'wp-upload-media' );
+		if ( false !== $this->preserved_state['wp_upload_media'] ) {
+			$script = $this->preserved_state['wp_upload_media'];
+			wp_register_script(
+				'wp-upload-media',
+				$script->src,
+				$script->deps,
+				$script->ver,
+				$script->args
+			);
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * The enqueue callback is hooked on admin_enqueue_scripts.
+	 */
+	public function test_hooked_on_admin_enqueue_scripts() {
+		$this->assertSame( 10, has_action( 'admin_enqueue_scripts', 'csme_enqueue_media_new_scripts' ) );
+	}
+
+	/**
+	 * Script is enqueued on media-new.php.
+	 */
+	public function test_script_enqueued_on_media_new_php() {
+		csme_enqueue_media_new_scripts( 'media-new.php' );
+
+		$this->assertTrue( wp_script_is( 'csme-media-new-upload', 'enqueued' ) );
+	}
+
+	/**
+	 * Script is not enqueued on other admin pages.
+	 */
+	public function test_script_not_enqueued_on_other_pages() {
+		csme_enqueue_media_new_scripts( 'upload.php' );
+		csme_enqueue_media_new_scripts( 'options-general.php' );
+
+		$this->assertFalse( wp_script_is( 'csme-media-new-upload', 'enqueued' ) );
+	}
+
+	/**
+	 * Script is not enqueued when the upload-media package is not registered.
+	 */
+	public function test_script_not_enqueued_without_upload_media() {
+		wp_deregister_script( 'wp-upload-media' );
+
+		csme_enqueue_media_new_scripts( 'media-new.php' );
+
+		$this->assertFalse( wp_script_is( 'csme-media-new-upload', 'enqueued' ) );
+	}
+
+	/**
+	 * The script depends on plupload-handlers and wp-upload-media, not
+	 * wp-block-editor or media-views (which media-new.php never loads).
+	 */
+	public function test_dependencies() {
+		csme_enqueue_media_new_scripts( 'media-new.php' );
+
+		$script = wp_scripts()->registered['csme-media-new-upload'];
+		$this->assertContains( 'plupload-handlers', $script->deps );
+		$this->assertContains( 'wp-upload-media', $script->deps );
+		$this->assertNotContains( 'wp-block-editor', $script->deps );
+		$this->assertNotContains( 'media-views', $script->deps );
+	}
+
+	/**
+	 * The inline settings are exactly the JSON encoding of the shared
+	 * grid settings, under the media-new global.
+	 */
+	public function test_inline_settings_match_shared_settings() {
+		csme_enqueue_media_new_scripts( 'media-new.php' );
+
+		$before = wp_scripts()->get_data( 'csme-media-new-upload', 'before' );
+		$inline = implode( "\n", (array) $before );
+
+		$this->assertStringContainsString(
+			'window.csmeMediaNewSettings = ' . wp_json_encode( csme_get_media_library_settings() ) . ';',
+			$inline
+		);
+	}
+}

--- a/tests/Test_Media_New_Isolation.php
+++ b/tests/Test_Media_New_Isolation.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Tests for csme_set_up_media_new_isolation().
+ *
+ * @package ClientSideMediaEverywhere
+ */
+
+class Test_Media_New_Isolation extends WP_UnitTestCase {
+
+	/**
+	 * Preserved state for cleanup.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private $preserved_state = array();
+
+	/**
+	 * Set up before each test: register a stub upload-media script.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// Preserve existing wp-upload-media registration if any.
+		$this->preserved_state['wp_upload_media'] = wp_scripts()->query( 'wp-upload-media', 'registered' );
+
+		// Isolation is gated on the upload-media package being registered.
+		wp_register_script( 'wp-upload-media', 'https://example.org/upload-media.js', array(), '1.0', true );
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down() {
+		remove_all_filters( 'csme_use_coep_coop' );
+		unset( $_SERVER['HTTP_USER_AGENT'] );
+		wp_set_current_user( 0 );
+
+		// Restore pre-existing wp-upload-media registration or deregister.
+		wp_deregister_script( 'wp-upload-media' );
+		if ( false !== $this->preserved_state['wp_upload_media'] ) {
+			$script = $this->preserved_state['wp_upload_media'];
+			wp_register_script(
+				'wp-upload-media',
+				$script->src,
+				$script->deps,
+				$script->ver,
+				$script->args
+			);
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * The isolation setup is hooked on load-media-new.php.
+	 */
+	public function test_hooked_on_load_media_new() {
+		$this->assertSame( 20, has_action( 'load-media-new.php', 'csme_set_up_media_new_isolation' ) );
+	}
+
+	/**
+	 * No output buffer starts when no user is logged in.
+	 */
+	public function test_no_buffer_when_logged_out() {
+		add_filter( 'csme_use_coep_coop', '__return_true' );
+
+		wp_set_current_user( 0 );
+
+		$ob_level_before = ob_get_level();
+		csme_set_up_media_new_isolation();
+		$ob_level_after = ob_get_level();
+
+		$this->assertSame( $ob_level_before, $ob_level_after );
+	}
+
+	/**
+	 * No output buffer starts when the user cannot upload files.
+	 */
+	public function test_no_buffer_when_user_cannot_upload() {
+		add_filter( 'csme_use_coep_coop', '__return_true' );
+
+		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $user_id );
+
+		$ob_level_before = ob_get_level();
+		csme_set_up_media_new_isolation();
+		$ob_level_after = ob_get_level();
+
+		$this->assertSame( $ob_level_before, $ob_level_after );
+	}
+
+	/**
+	 * No output buffer starts when the upload-media package is missing.
+	 *
+	 * Without the package the pipeline cannot run, so no isolation
+	 * headers should be sent either.
+	 */
+	public function test_no_buffer_without_upload_media_package() {
+		add_filter( 'csme_use_coep_coop', '__return_true' );
+
+		$user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $user_id );
+
+		wp_deregister_script( 'wp-upload-media' );
+
+		$ob_level_before = ob_get_level();
+		csme_set_up_media_new_isolation();
+		$ob_level_after = ob_get_level();
+
+		$this->assertSame( $ob_level_before, $ob_level_after );
+	}
+
+	/**
+	 * The COEP/COOP output buffer starts for a capable user.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_starts_coep_coop_buffer() {
+		add_filter( 'csme_use_coep_coop', '__return_true' );
+
+		$user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $user_id );
+
+		$ob_level_before = ob_get_level();
+		csme_set_up_media_new_isolation();
+		$ob_level_after = ob_get_level();
+
+		$this->assertSame( $ob_level_before + 1, $ob_level_after );
+
+		while ( ob_get_level() > $ob_level_before ) {
+			ob_end_clean();
+		}
+	}
+
+	/**
+	 * The DIP output buffer starts when Chromium 137+ is detected.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_starts_dip_buffer_for_chromium() {
+		// Force the DIP path: COEP/COOP disabled and a modern Chromium version.
+		add_filter( 'csme_use_coep_coop', '__return_false' );
+
+		/*
+		 * Core's real wp_start_cross_origin_isolation_output_buffer() (WP 7.1+)
+		 * reads the User-Agent and only starts the buffer for Chromium 137+,
+		 * so provide one rather than stubbing the version check.
+		 */
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36';
+
+		if ( ! function_exists( 'wp_start_cross_origin_isolation_output_buffer' ) ) {
+			// Environments predating WP 7.1: stub the buffer function the
+			// plugin dispatches to, honoring the same Chromium check.
+			function wp_start_cross_origin_isolation_output_buffer() {
+				if ( isset( $_SERVER['HTTP_USER_AGENT'] )
+					&& preg_match( '#Chrome/(\d+)#', $_SERVER['HTTP_USER_AGENT'], $matches )
+					&& (int) $matches[1] >= 137 ) {
+					ob_start();
+				}
+			}
+		}
+
+		$user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $user_id );
+
+		$ob_level_before = ob_get_level();
+		csme_set_up_media_new_isolation();
+		$ob_level_after = ob_get_level();
+
+		$this->assertSame( $ob_level_before + 1, $ob_level_after );
+
+		while ( ob_get_level() > $ob_level_before ) {
+			ob_end_clean();
+		}
+	}
+
+	/**
+	 * No buffer starts on the DIP path when core's buffer function is absent.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_no_buffer_when_no_dip_function_available() {
+		add_filter( 'csme_use_coep_coop', '__return_false' );
+
+		$user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $user_id );
+
+		// Neither core nor Gutenberg buffer functions exist in the base test env,
+		// and COEP/COOP is filtered off, so nothing should start a buffer.
+		if ( function_exists( 'wp_start_cross_origin_isolation_output_buffer' )
+			|| function_exists( 'gutenberg_start_cross_origin_isolation_output_buffer' ) ) {
+			$this->markTestSkipped( 'A DIP buffer function is defined in this environment.' );
+		}
+
+		$ob_level_before = ob_get_level();
+		csme_set_up_media_new_isolation();
+		$ob_level_after = ob_get_level();
+
+		$this->assertSame( $ob_level_before, $ob_level_after );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -33,6 +33,7 @@ require_once $_tests_dir . '/includes/functions.php';
 function _manually_load_plugin() {
 	require_once CSME_PLUGIN_DIR . 'includes/cross-origin-isolation.php';
 	require_once CSME_PLUGIN_DIR . 'includes/media-library.php';
+	require_once CSME_PLUGIN_DIR . 'includes/media-new.php';
 }
 
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,11 +10,6 @@ define( 'CSME_VERSION', '1.1.0' );
 define( 'CSME_PLUGIN_DIR', dirname( __DIR__ ) . '/' );
 define( 'CSME_PLUGIN_URL', 'http://example.org/wp-content/plugins/client-side-media-everywhere/' );
 
-// Stub the client-side media processing gate so the plugin file can load.
-function wp_is_client_side_media_processing_enabled() {
-	return true;
-}
-
 // Determine the WP tests directory.
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -37,6 +37,7 @@ require_once $_tests_dir . '/includes/functions.php';
  */
 function _manually_load_plugin() {
 	require_once CSME_PLUGIN_DIR . 'includes/cross-origin-isolation.php';
+	require_once CSME_PLUGIN_DIR . 'includes/media-library.php';
 }
 
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );

--- a/tests/e2e/specs/media-library-upload.spec.ts
+++ b/tests/e2e/specs/media-library-upload.spec.ts
@@ -141,6 +141,73 @@ test.describe( 'Media Library grid uploads', () => {
 		expect( asyncUploads ).toEqual( [] );
 	} );
 
+	test( 'warns before leaving while a pipeline upload is in flight', async ( {
+		page,
+	} ) => {
+		await page.goto( '/wp-admin/upload.php?mode=grid' );
+
+		const isolated = await page.evaluate( () =>
+			Boolean( window.crossOriginIsolated )
+		);
+		test.skip(
+			! isolated,
+			'The client-side pipeline requires a cross-origin isolated context'
+		);
+
+		// Hold sideload requests so the upload stays in flight at a
+		// deterministic point.
+		const heldRoutes: Array< {
+			continue: () => Promise< void >;
+		} > = [];
+		let holding = true;
+		await page.route(
+			( url ) => decodeURIComponent( url.href ).includes( '/sideload' ),
+			async ( route ) => {
+				if ( holding ) {
+					heldRoutes.push( route );
+					return;
+				}
+				await route.continue();
+			}
+		);
+		const sideloadRequested = page.waitForRequest(
+			( request ) =>
+				decodeURIComponent( request.url() ).includes( '/sideload' ),
+			{ timeout: 60_000 }
+		);
+
+		const fileInput = page.locator( FILE_INPUT_SELECTOR ).first();
+		await fileInput.waitFor( { state: 'attached', timeout: 30_000 } );
+		await fileInput.setInputFiles( TEST_IMAGE_PATH );
+		await sideloadRequested;
+
+		// A synthetic cancelable event exercises the guard's listener
+		// without triggering the real (untestable) browser prompt.
+		const preventedWhileUploading = await page.evaluate( () => {
+			const event = new Event( 'beforeunload', { cancelable: true } );
+			window.dispatchEvent( event );
+			return event.defaultPrevented;
+		} );
+		expect( preventedWhileUploading ).toBe( true );
+
+		// Release the held requests, let the upload finish, and verify the
+		// guard disengages once nothing is in flight anymore.
+		holding = false;
+		for ( const route of heldRoutes ) {
+			await route.continue();
+		}
+		await expect(
+			page.locator( 'li.attachment:not(.uploading)' ).first()
+		).toBeVisible( { timeout: 60_000 } );
+
+		const preventedAfterUpload = await page.evaluate( () => {
+			const event = new Event( 'beforeunload', { cancelable: true } );
+			window.dispatchEvent( event );
+			return event.defaultPrevented;
+		} );
+		expect( preventedAfterUpload ).toBe( false );
+	} );
+
 	test( 'shows an error for a disallowed file type', async ( {
 		page,
 	} ) => {

--- a/tests/e2e/specs/media-library-upload.spec.ts
+++ b/tests/e2e/specs/media-library-upload.spec.ts
@@ -1,0 +1,170 @@
+/**
+ * External dependencies
+ */
+import * as path from 'path';
+
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+const TEST_IMAGE_PATH = path.join(
+	__dirname,
+	'..',
+	'fixtures',
+	'test-image.jpg'
+);
+
+// The plupload HTML5 runtime creates this hidden file input over the
+// "Add New" browse button; setting files on it triggers FilesAdded.
+const FILE_INPUT_SELECTOR = '.moxie-shim-html5 input[type="file"]';
+
+test.describe( 'Media Library grid uploads', () => {
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllMedia();
+	} );
+
+	test( 'isolates the grid on Firefox and WebKit', async ( {
+		page,
+		browserName,
+	} ) => {
+		test.skip(
+			browserName === 'chromium',
+			'Chromium uses Document-Isolation-Policy, covered separately'
+		);
+
+		const responsePromise = page.waitForResponse(
+			( resp ) =>
+				resp.url().includes( '/wp-admin/upload.php' ) &&
+				resp.request().resourceType() === 'document' &&
+				resp.status() === 200
+		);
+
+		await page.goto( '/wp-admin/upload.php?mode=grid' );
+
+		const headers = ( await responsePromise ).headers();
+		expect( headers[ 'cross-origin-opener-policy' ] ).toBe( 'same-origin' );
+		expect( headers[ 'cross-origin-embedder-policy' ] ).toMatch(
+			/^(credentialless|require-corp)$/
+		);
+
+		const isolated = await page.evaluate( () =>
+			Boolean( window.crossOriginIsolated )
+		);
+		expect( isolated ).toBe( true );
+	} );
+
+	test( 'sends the DIP header on the grid on Chromium', async ( {
+		page,
+		browserName,
+	} ) => {
+		test.skip(
+			browserName !== 'chromium',
+			'Only Chromium 137+ receives Document-Isolation-Policy'
+		);
+
+		const responsePromise = page.waitForResponse(
+			( resp ) =>
+				resp.url().includes( '/wp-admin/upload.php' ) &&
+				resp.request().resourceType() === 'document' &&
+				resp.status() === 200
+		);
+
+		await page.goto( '/wp-admin/upload.php?mode=grid' );
+
+		const headers = ( await responsePromise ).headers();
+		// Core does not isolate upload.php, so the plugin starts the DIP
+		// buffer here itself.
+		expect( headers[ 'document-isolation-policy' ] ).toBe(
+			'isolate-and-credentialless'
+		);
+	} );
+
+	test( 'uploads an image through the client-side pipeline', async ( {
+		page,
+	} ) => {
+		await page.goto( '/wp-admin/upload.php?mode=grid' );
+
+		const isolated = await page.evaluate( () =>
+			Boolean( window.crossOriginIsolated )
+		);
+		// Playwright's Chromium build lacks Document-Isolation-Policy, so
+		// isolation is legitimately unavailable there and the pipeline
+		// falls back to classic uploads. Only assert where isolation is real.
+		test.skip(
+			! isolated,
+			'The client-side pipeline requires a cross-origin isolated context'
+		);
+
+		// The REST route may be a pretty permalink (/wp/v2/media) or the plain
+		// form (index.php?rest_route=%2Fwp%2Fv2%2Fmedia), so match on the
+		// decoded URL.
+		let mediaCreateCount = 0;
+		let sideloadCount = 0;
+		let finalizeCount = 0;
+		const asyncUploads: string[] = [];
+		page.on( 'request', ( request ) => {
+			if ( request.method() !== 'POST' ) {
+				return;
+			}
+			const url = request.url();
+			if ( url.includes( '/async-upload.php' ) ) {
+				asyncUploads.push( url );
+				return;
+			}
+			const decoded = decodeURIComponent( url );
+			if ( /\/wp\/v2\/media\/\d+\/sideload/.test( decoded ) ) {
+				sideloadCount++;
+			} else if ( /\/wp\/v2\/media\/\d+\/finalize/.test( decoded ) ) {
+				finalizeCount++;
+			} else if ( /\/wp\/v2\/media(?:[?&]|$)/.test( decoded ) ) {
+				mediaCreateCount++;
+			}
+		} );
+
+		const fileInput = page.locator( FILE_INPUT_SELECTOR ).first();
+		await fileInput.waitFor( { state: 'attached', timeout: 30_000 } );
+		await fileInput.setInputFiles( TEST_IMAGE_PATH );
+
+		// The finalized attachment resolves to a normal (non-uploading) tile.
+		await expect(
+			page.locator( 'li.attachment:not(.uploading)' ).first()
+		).toBeVisible( { timeout: 60_000 } );
+
+		// The original upload and every sideload go through the REST API,
+		// and the upload is finalized exactly once.
+		expect( mediaCreateCount ).toBeGreaterThanOrEqual( 1 );
+		expect( sideloadCount ).toBeGreaterThanOrEqual( 1 );
+		expect( finalizeCount ).toBe( 1 );
+
+		// Nothing goes through the classic async-upload.php endpoint.
+		expect( asyncUploads ).toEqual( [] );
+	} );
+
+	test( 'shows an error for a disallowed file type', async ( {
+		page,
+	} ) => {
+		await page.goto( '/wp-admin/upload.php?mode=grid' );
+
+		const isolated = await page.evaluate( () =>
+			Boolean( window.crossOriginIsolated )
+		);
+		test.skip(
+			! isolated,
+			'The client-side pipeline requires a cross-origin isolated context'
+		);
+
+		const fileInput = page.locator( FILE_INPUT_SELECTOR ).first();
+		await fileInput.waitFor( { state: 'attached', timeout: 30_000 } );
+		await fileInput.setInputFiles( {
+			name: 'disallowed.xyz',
+			mimeType: 'application/octet-stream',
+			buffer: Buffer.from( 'not an allowed file type' ),
+		} );
+
+		// The Manage frame renders rejected uploads in the error sidebar.
+		await expect(
+			page.locator( '.upload-error, .upload-errors' ).first()
+		).toBeVisible( { timeout: 30_000 } );
+	} );
+} );

--- a/tests/e2e/specs/media-new-upload.spec.ts
+++ b/tests/e2e/specs/media-new-upload.spec.ts
@@ -1,0 +1,245 @@
+/**
+ * External dependencies
+ */
+import * as path from 'path';
+
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+const TEST_IMAGE_PATH = path.join(
+	__dirname,
+	'..',
+	'fixtures',
+	'test-image.jpg'
+);
+
+// The plupload HTML5 runtime creates this hidden file input over the
+// "Select Files" browse button; setting files on it triggers FilesAdded.
+const FILE_INPUT_SELECTOR = '.moxie-shim-html5 input[type="file"]';
+
+test.describe( 'Add New Media File client-side uploads', () => {
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllMedia();
+	} );
+
+	test( 'isolates the screen on Firefox and WebKit', async ( {
+		page,
+		browserName,
+	} ) => {
+		test.skip(
+			browserName === 'chromium',
+			'Chromium uses Document-Isolation-Policy, covered separately'
+		);
+
+		const responsePromise = page.waitForResponse(
+			( resp ) =>
+				resp.url().includes( '/wp-admin/media-new.php' ) &&
+				resp.request().resourceType() === 'document' &&
+				resp.status() === 200
+		);
+
+		await page.goto( '/wp-admin/media-new.php' );
+
+		const headers = ( await responsePromise ).headers();
+		expect( headers[ 'cross-origin-opener-policy' ] ).toBe( 'same-origin' );
+		expect( headers[ 'cross-origin-embedder-policy' ] ).toMatch(
+			/^(credentialless|require-corp)$/
+		);
+
+		const isolated = await page.evaluate( () =>
+			Boolean( window.crossOriginIsolated )
+		);
+		expect( isolated ).toBe( true );
+	} );
+
+	test( 'sends the DIP header on Chromium', async ( {
+		page,
+		browserName,
+	} ) => {
+		test.skip(
+			browserName !== 'chromium',
+			'Only Chromium 137+ receives Document-Isolation-Policy'
+		);
+
+		const responsePromise = page.waitForResponse(
+			( resp ) =>
+				resp.url().includes( '/wp-admin/media-new.php' ) &&
+				resp.request().resourceType() === 'document' &&
+				resp.status() === 200
+		);
+
+		await page.goto( '/wp-admin/media-new.php' );
+
+		const headers = ( await responsePromise ).headers();
+		// Core does not isolate media-new.php, so the plugin starts the DIP
+		// buffer here itself.
+		expect( headers[ 'document-isolation-policy' ] ).toBe(
+			'isolate-and-credentialless'
+		);
+	} );
+
+	test( 'uploads an image through the client-side pipeline', async ( {
+		page,
+	} ) => {
+		await page.goto( '/wp-admin/media-new.php' );
+
+		const isolated = await page.evaluate( () =>
+			Boolean( window.crossOriginIsolated )
+		);
+		// Playwright's Chromium build lacks Document-Isolation-Policy, so
+		// isolation is legitimately unavailable there and the pipeline
+		// falls back to classic uploads. Only assert where isolation is real.
+		test.skip(
+			! isolated,
+			'The client-side pipeline requires a cross-origin isolated context'
+		);
+
+		// The REST route may be a pretty permalink (/wp/v2/media) or the plain
+		// form (index.php?rest_route=%2Fwp%2Fv2%2Fmedia), so match on the
+		// decoded URL.
+		let mediaCreateCount = 0;
+		let sideloadCount = 0;
+		let finalizeCount = 0;
+		const asyncUploads: string[] = [];
+		page.on( 'request', ( request ) => {
+			if ( request.method() !== 'POST' ) {
+				return;
+			}
+			const url = request.url();
+			if ( url.includes( '/async-upload.php' ) ) {
+				// The pipeline still POSTs to async-upload.php once per
+				// upload to fetch the finished item markup (fetch=3, no file
+				// payload); only file uploads must not go through it.
+				const postData = request.postData() || '';
+				if ( ! /(^|&)fetch=/.test( postData ) ) {
+					asyncUploads.push( url );
+				}
+				return;
+			}
+			const decoded = decodeURIComponent( url );
+			if ( /\/wp\/v2\/media\/\d+\/sideload/.test( decoded ) ) {
+				sideloadCount++;
+			} else if ( /\/wp\/v2\/media\/\d+\/finalize/.test( decoded ) ) {
+				finalizeCount++;
+			} else if ( /\/wp\/v2\/media(?:[?&]|$)/.test( decoded ) ) {
+				mediaCreateCount++;
+			}
+		} );
+
+		const fileInput = page.locator( FILE_INPUT_SELECTOR ).first();
+		await fileInput.waitFor( { state: 'attached', timeout: 30_000 } );
+		await fileInput.setInputFiles( TEST_IMAGE_PATH );
+
+		// The finished attachment row renders with the Edit link fetched
+		// from the async-upload.php markup endpoint.
+		await expect(
+			page.locator( '#media-items .media-item .edit-attachment' ).first()
+		).toBeVisible( { timeout: 60_000 } );
+
+		// The original upload and every sideload go through the REST API,
+		// and the upload is finalized exactly once.
+		expect( mediaCreateCount ).toBeGreaterThanOrEqual( 1 );
+		expect( sideloadCount ).toBeGreaterThanOrEqual( 1 );
+		expect( finalizeCount ).toBe( 1 );
+
+		// No file upload goes through the classic async-upload.php endpoint.
+		expect( asyncUploads ).toEqual( [] );
+	} );
+
+	test( 'warns before leaving while a pipeline upload is in flight', async ( {
+		page,
+	} ) => {
+		await page.goto( '/wp-admin/media-new.php' );
+
+		const isolated = await page.evaluate( () =>
+			Boolean( window.crossOriginIsolated )
+		);
+		test.skip(
+			! isolated,
+			'The client-side pipeline requires a cross-origin isolated context'
+		);
+
+		// Hold sideload requests so the upload stays in flight at a
+		// deterministic point.
+		const heldRoutes: Array< {
+			continue: () => Promise< void >;
+		} > = [];
+		let holding = true;
+		await page.route(
+			( url ) => decodeURIComponent( url.href ).includes( '/sideload' ),
+			async ( route ) => {
+				if ( holding ) {
+					heldRoutes.push( route );
+					return;
+				}
+				await route.continue();
+			}
+		);
+		const sideloadRequested = page.waitForRequest(
+			( request ) =>
+				decodeURIComponent( request.url() ).includes( '/sideload' ),
+			{ timeout: 60_000 }
+		);
+
+		const fileInput = page.locator( FILE_INPUT_SELECTOR ).first();
+		await fileInput.waitFor( { state: 'attached', timeout: 30_000 } );
+		await fileInput.setInputFiles( TEST_IMAGE_PATH );
+		await sideloadRequested;
+
+		// A synthetic cancelable event exercises the guard's listener
+		// without triggering the real (untestable) browser prompt.
+		const preventedWhileUploading = await page.evaluate( () => {
+			const event = new Event( 'beforeunload', { cancelable: true } );
+			window.dispatchEvent( event );
+			return event.defaultPrevented;
+		} );
+		expect( preventedWhileUploading ).toBe( true );
+
+		// Release the held requests, let the upload finish, and verify the
+		// guard disengages once nothing is in flight anymore.
+		holding = false;
+		for ( const route of heldRoutes ) {
+			await route.continue();
+		}
+		await expect(
+			page.locator( '#media-items .media-item .edit-attachment' ).first()
+		).toBeVisible( { timeout: 60_000 } );
+
+		const preventedAfterUpload = await page.evaluate( () => {
+			const event = new Event( 'beforeunload', { cancelable: true } );
+			window.dispatchEvent( event );
+			return event.defaultPrevented;
+		} );
+		expect( preventedAfterUpload ).toBe( false );
+	} );
+
+	test( 'shows an error for a disallowed file type', async ( { page } ) => {
+		await page.goto( '/wp-admin/media-new.php' );
+
+		const isolated = await page.evaluate( () =>
+			Boolean( window.crossOriginIsolated )
+		);
+		test.skip(
+			! isolated,
+			'The client-side pipeline requires a cross-origin isolated context'
+		);
+
+		const fileInput = page.locator( FILE_INPUT_SELECTOR ).first();
+		await fileInput.waitFor( { state: 'attached', timeout: 30_000 } );
+		await fileInput.setInputFiles( {
+			name: 'disallowed.xyz',
+			mimeType: 'application/octet-stream',
+			buffer: Buffer.from( 'not an allowed file type' ),
+		} );
+
+		// The error surfaces either as a pipeline per-item error
+		// (itemAjaxError renders .error-div inside the media item) or as a
+		// plupload extension rejection (a .media-item.error element),
+		// depending on which layer rejects the file first.
+		await expect(
+			page.locator( '.media-item .error-div, .media-item.error' ).first()
+		).toBeVisible( { timeout: 30_000 } );
+	} );
+} );


### PR DESCRIPTION
Fixes #44.

WordPress core's client-side media pipeline (wasm-vips) only runs in the block editor: it swaps the editor's `mediaUpload` setting and never touches the classic Media Library grid, which uploads via `wp.Uploader`/plupload to `async-upload.php`. This PR extends the pipeline to the Media Library grid at `upload.php` so grid uploads are processed in the browser (REST upload of the original, client-side thumbnails, sideload, finalize) instead of server-side.

## What changed

**Commit 1 - Extend cross-origin isolation to the grid.** New `includes/media-library.php` sets up isolation on `load-upload.php` (grid mode, capable users only): the existing COEP/COOP buffer for Firefox/Safari/Chrome < 137, or core's `wp_start_cross_origin_isolation_output_buffer()` for Chromium 137+. Core does **not** isolate `upload.php`, so the plugin sends the `Document-Isolation-Policy` header there itself - this is net-new Chromium behavior required for the feature to work in Chrome. The existing observer script is enqueued on the grid with a dependency-free list so block editor bundles are not dragged onto the page.

**Commit 2 - Route grid uploads through the pipeline.** New `js/media-library-upload.js` (vanilla IIFE, matching the existing script) configures the `@wordpress/upload-media` store via `MediaUploadProvider` (`useSubRegistry: false`), wraps `wp.Uploader.prototype.init` to intercept `FilesAdded` at a higher plupload priority, and routes each file through the store while mirroring wp-plupload's placeholder tiles, progress, queue reset, and error sidebar so the grid UI works unchanged. `mediaSideload`/`mediaFinalize` are reimplemented as thin `apiFetch` wrappers rather than using private `@wordpress/media-utils` APIs. When the browser lacks client-side support - or if settings have not landed - the interceptor defers to the classic handler, so uploads always work (degradation, never data loss).

**Commit 3 - E2E coverage.** New spec asserting isolation headers on `upload.php` (COEP/COOP on Firefox/WebKit, the new DIP header on Chromium), the happy-path upload (create + sideload + finalize via REST, zero `async-upload.php` requests), and the disallowed-file-type error path.

**Commit 4 - Docs.** README and readme.txt describe the new surface, the DIP-on-`upload.php` behavior, and the grid-only limitation.

## Verification

- `composer lint`, `composer phpstan` (no errors), `composer test` (63 tests pass; 3 header tests skipped locally without Xdebug).
- `npm run test:e2e -- media-library-upload` against wp-env (core master / 7.1-alpha): passes on chromium, firefox, and webkit. Firefox and WebKit run the full pipeline and confirm REST create/sideload/finalize with no `async-upload.php`; Chromium confirms the DIP header and skips the upload assertions because Playwright's Chromium build ships without Document-Isolation-Policy.

## Scope

**In:** `upload.php` grid mode - drag-and-drop and "Add New", both of which flow through the one grid `wp.Uploader`; the new DIP-on-`upload.php` behavior for Chromium.

**Out (tracked in #48):** list-mode "Add New" / `media-new.php` (separate uploader path), and a `beforeunload` warning during in-progress uploads.

## Manual verification checklist

- [ ] Real Safari: grid upload processes client-side under `require-corp`.
- [ ] HEIC upload converts (HEIC -> JPEG) on the grid.
- [ ] Animated GIF produces a video companion.
- [ ] Image larger than available wasm memory falls back to server-side sub-sizes.
- [ ] Drag 10+ mixed files at once; all tiles resolve.
- [ ] Close the tab mid-upload (no guard yet - see #48).
- [ ] Chromium < 137 uses the COEP/COOP path on the grid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled browser-based media processing for WordPress Media Library **grid** uploads and **Media > Add New Media File** uploads, including client-side thumbnail generation and REST-backed upload/finalize flow.
  * Restores cross-origin isolation for these upload screens (with Chrome Document Isolation Policy support) and adds a “warn before leaving” guard during in-flight uploads.
  * Falls back to classic server-side uploads when browser processing isn’t supported.
* **Documentation**
  * Updated README/help and FAQ to cover both upload screens, grid vs list behavior, and browser compatibility notes.
* **Tests**
  * Added/expanded PHPUnit and Playwright coverage for isolation, enqueue conditions, and upload outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->