### PR TITLE
Document the tradeoffs of COEP/COOP isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Enables client-side media processing on Firefox and Safari via COEP/COOP cross-o
 
 WordPress 7.1 and Gutenberg include client-side media processing powered by WebAssembly (wasm-vips). This requires cross-origin isolation, which is achieved via Document-Isolation-Policy (DIP) on Chrome 137+.
 
-However, Firefox and Safari do not yet support DIP, so client-side media processing is disabled on those browsers.
+However, Firefox and Safari do not yet support DIP, and neither does Chrome before 137, so client-side media processing is disabled on those browsers.
 
 This plugin restores support by sending the older COEP/COOP headers on browsers where DIP is not available:
 
@@ -16,6 +16,22 @@ This plugin restores support by sending the older COEP/COOP headers on browsers 
 - Adds `crossorigin="anonymous"` attributes to cross-origin resources.
 - Adds `credentialless` attribute to iframes so they continue working under COEP.
 - Filters embed previews for providers that do not support credentialless iframes (Facebook, SmugMug).
+
+## Tradeoffs
+
+Cross-origin isolation is a security boundary. It works by making the browser refuse cross-origin resources that have not opted in, or strip their credentials. That is what unlocks `SharedArrayBuffer` and wasm-vips, but it is also why Chrome moved to Document-Isolation-Policy: DIP gives the same isolation without imposing these restrictions on the rest of the page.
+
+**Scope of the impact.** Only browsers that receive the COEP/COOP headers are affected - Firefox, Safari, and Chrome < 137 - and only on block editor screens (post editor, site editor, block widgets) for users who can upload files. The front-end, the rest of wp-admin, and Chrome 137+ are untouched.
+
+What can break on those screens:
+
+- **oEmbed previews.** Embeds are iframed. Under `credentialless` (Firefox, Chrome < 137) the plugin adds the `credentialless` attribute so they still load, but without cookies - embeds that need a logged-in session render logged-out or not at all. Facebook and SmugMug do not work with credentialless iframes, so their live previews are disabled in the editor and the placeholder is shown instead. Safari does not support `credentialless` at all, so under `require-corp` any embed whose provider does not send its own COEP header is blocked outright.
+- **Media served from third-party origins.** Images, video, audio, and fonts loaded into the editor from a CDN or another domain must opt in with `Cross-Origin-Resource-Policy`. Under `credentialless` they load but without credentials, so anything behind a signed cookie fails. Under `require-corp` (Safari) they are blocked unless the server sends CORP - the plugin adds `crossorigin="anonymous"` to cross-origin images to give them a CORS path instead, which only helps if the server sends `Access-Control-Allow-Origin`.
+- **Popup-based authentication.** `Cross-Origin-Opener-Policy: same-origin` severs the `window.opener` link to cross-origin popups. Plugins that connect to an external service by opening an OAuth popup and waiting for it to call back into the opener will hang.
+- **Plugins that load editor assets cross-origin.** Any third-party script, stylesheet, or font pulled into the editor from another origin is subject to the same rules.
+- **The classic block.** The classic block and other TinyMCE-based UIs commonly load third-party assets, and are a frequent place for the failures above to surface.
+
+These are the same constraints the block editor lived with before Chrome shipped Document-Isolation-Policy. If you hit one, you can suppress the headers per environment or per user with the [`csme_use_coep_coop` filter](#disable-coepcoop-headers-programmatically), or deactivate the plugin - media processing then falls back to the server on the affected browsers, which is the behavior without this plugin installed.
 
 ## Requirements
 

--- a/readme.txt
+++ b/readme.txt
@@ -14,7 +14,7 @@ Enables client-side media processing on Firefox and Safari via COEP/COOP cross-o
 
 WordPress 7.1 and Gutenberg include client-side media processing powered by WebAssembly (wasm-vips). This requires cross-origin isolation, which is achieved via Document-Isolation-Policy (DIP) on Chrome 137+.
 
-However, Firefox and Safari do not yet support DIP, so client-side media processing is disabled on those browsers.
+However, Firefox and Safari do not yet support DIP, and neither does Chrome before 137, so client-side media processing is disabled on those browsers.
 
 This plugin restores support for Firefox and Safari by sending the older COEP/COOP headers (Cross-Origin-Embedder-Policy / Cross-Origin-Opener-Policy) on browsers where DIP is not available.
 
@@ -30,6 +30,22 @@ This plugin restores support for Firefox and Safari by sending the older COEP/CO
 * WordPress 6.8+ with the Gutenberg plugin (which provides the client-side media processing feature), or WordPress 7.1+.
 * The client-side media processing feature must be enabled (it is on by default in secure contexts).
 * HTTPS (or localhost): client-side media processing requires a secure context.
+
+== Tradeoffs ==
+
+Cross-origin isolation is a security boundary. It works by making the browser refuse cross-origin resources that have not opted in, or strip their credentials. That is what unlocks SharedArrayBuffer and wasm-vips, but it is also why Chrome moved to Document-Isolation-Policy: DIP gives the same isolation without imposing these restrictions on the rest of the page.
+
+Only browsers that receive the COEP/COOP headers are affected - Firefox, Safari, and Chrome < 137 - and only on block editor screens (post editor, site editor, block widgets) for users who can upload files. The front-end, the rest of wp-admin, and Chrome 137+ are untouched.
+
+What can break on those screens:
+
+* **oEmbed previews.** Embeds are iframed. Under `credentialless` (Firefox, Chrome < 137) the plugin adds the `credentialless` attribute so they still load, but without cookies - embeds that need a logged-in session render logged-out or not at all. Facebook and SmugMug do not work with credentialless iframes, so their live previews are disabled in the editor and the placeholder is shown instead. Safari does not support `credentialless` at all, so under `require-corp` any embed whose provider does not send its own COEP header is blocked outright.
+* **Media served from third-party origins.** Images, video, audio, and fonts loaded into the editor from a CDN or another domain must opt in with `Cross-Origin-Resource-Policy`. Under `credentialless` they load but without credentials, so anything behind a signed cookie fails. Under `require-corp` (Safari) they are blocked unless the server sends CORP - the plugin adds `crossorigin="anonymous"` to cross-origin images to give them a CORS path instead, which only helps if the server sends `Access-Control-Allow-Origin`.
+* **Popup-based authentication.** `Cross-Origin-Opener-Policy: same-origin` severs the `window.opener` link to cross-origin popups. Plugins that connect to an external service by opening an OAuth popup and waiting for it to call back into the opener will hang.
+* **Plugins that load editor assets cross-origin.** Any third-party script, stylesheet, or font pulled into the editor from another origin is subject to the same rules.
+* **The classic block.** The classic block and other TinyMCE-based UIs commonly load third-party assets, and are a frequent place for the failures above to surface.
+
+These are the same constraints the block editor lived with before Chrome shipped Document-Isolation-Policy. If you hit one, suppress the headers with the `csme_use_coep_coop` filter or deactivate the plugin - media processing then falls back to the server on the affected browsers, which is the behavior without this plugin installed.
 
 == Installation ==
 
@@ -49,7 +65,7 @@ No. Chrome 137+ uses Document-Isolation-Policy, which is handled by WordPress co
 
 = Will this break my site? =
 
-The COEP/COOP headers are only sent on block editor admin pages, not on the front-end. Some third-party plugins that use iframes in the editor may be affected. If you experience issues, you can deactivate the plugin.
+Not the front-end: the COEP/COOP headers are only sent on block editor admin pages, and only on browsers that need them (Firefox, Safari, Chrome < 137). Within the editor on those browsers, cross-origin isolation can break oEmbed previews, media served from third-party origins, popup-based authentication flows, and plugins that load editor assets cross-origin. See the Tradeoffs section for the details and for how to turn the headers off if you hit one.
 
 = Can I disable the COEP/COOP behavior? =
 


### PR DESCRIPTION
## Why

The readme explained what the plugin turns on, but not what it costs.

Cross-origin isolation is a security boundary: it works by making the browser refuse cross-origin resources that have not opted in, or strip their credentials. That is exactly why Chrome moved to Document-Isolation-Policy - DIP gives the same isolation without imposing those restrictions on the rest of the page. Anyone installing this plugin is opting back into the old constraints on the browsers it covers, and the readme should say so before they find out from a broken embed.

## What changed

Adds a **Tradeoffs** section to `README.md` and `readme.txt` covering what cross-origin isolation can break in the editor:

- **oEmbed previews** - credentialless iframes load without cookies; Facebook and SmugMug previews are disabled outright; Safari's `require-corp` blocks any provider that does not send its own COEP header.
- **Media from third-party origins** - needs `Cross-Origin-Resource-Policy`, or CORS under `require-corp`.
- **Popup-based authentication** - `COOP: same-origin` severs `window.opener`, so OAuth connect flows hang.
- **Plugins loading editor assets cross-origin.**
- **The classic block** - TinyMCE UIs are a common place for the above to surface.

Each item is scoped to the browsers and screens that actually receive the headers, and the section closes by pointing at the `csme_use_coep_coop` filter as the escape hatch.

Also corrects both readmes, which framed the missing-DIP situation as a Firefox and Safari issue - Chrome before 137 lacks it too - and expands the "Will this break my site?" FAQ to point at the new section.

Documentation only; no code changes.