### PR TITLE
Update the plugin Author URI to the WordPress.org profile

### DIFF
--- a/client-side-media-everywhere.php
+++ b/client-side-media-everywhere.php
@@ -7,7 +7,7 @@
  * Requires at least: 6.8
  * Requires PHP: 7.4
  * Author:      Adam Silverstein
- * Author URI:  https://developer.wordpress.org
+ * Author URI:  https://profiles.wordpress.org/adamsilverstein/profile/
  * License:     GPL-2.0-or-later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: client-side-media-everywhere


### PR DESCRIPTION
The plugin header listed `https://developer.wordpress.org` as the Author URI, which is a generic docs site rather than anything identifying the author.

This points it at https://profiles.wordpress.org/adamsilverstein/profile/ instead, which is what the WordPress.org plugin directory expects for author attribution.

## Testing

The only change is the plugin header comment, so no behavior changes. Confirm the Author link in Plugins → Installed Plugins now goes to the WordPress.org profile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the plugin author information to link directly to the author’s WordPress.org profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->