### PR TITLE
Deploy workflow: fix the plugin deploy action version reference

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: WordPress Plugin Deploy
         id: deploy
-        uses: 10up/action-wordpress-plugin-deploy@v2.3.0
+        uses: 10up/action-wordpress-plugin-deploy@2.3.0
         with:
           generate-zip: true
         env:


### PR DESCRIPTION
The v1.1.0 release fired the deploy workflow and it failed right away with `Unable to resolve action 10up/action-wordpress-plugin-deploy@v2.3.0, unable to find version v2.3.0`.

See https://github.com/adamsilverstein/client-side-media-everywhere/actions/runs/30955340106

That action tags its releases without a leading `v` - the tag is `2.3.0`, not `v2.3.0` - so the reference never resolved and the job never got past setup.

## How has this been tested

- Listed the tags on the action repo to confirm the naming: `gh api repos/10up/action-wordpress-plugin-deploy/tags --jq '.[].name'` returns `2.3.0`, `2.2.2`, `2.2.1` and so on, with no `v` prefix on any of them.
- Read `action.yml` at 2.3.0 to confirm the inputs we pass are still correct: `generate-zip` is a valid input and `zip-path` is still an output, so the rest of the job does not need changing.
- Confirmed `SVN_USERNAME` and `SVN_PASSWORD` are both set as repository secrets.

I have not run the deploy itself, so this only proves the action will resolve, not that the SVN commit succeeds.

## Types of changes

- Point the deploy step at `10up/action-wordpress-plugin-deploy@2.3.0`.

Note: the release event has already fired for v1.1.0, and re-running that run would use the old workflow file. Once this merges, the way to kick it off again is to flip the v1.1.0 release back to draft and publish it a second time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the deployment workflow configuration to use the specified WordPress plugin deployment action version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->