### PR TITLE
Readme: lead the description with a plain explanation of what the plugin does, and bump to 1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 Enables client-side media processing on Firefox and Safari via COEP/COOP cross-origin isolation headers.
 
+## What this plugin does
+
+**In one sentence: this plugin gets client-side media processing working in Safari and Firefox, which WordPress otherwise only does in Chrome.**
+
+When you upload an image in Chrome, WordPress resizes and compresses it on your own device before it is sent, so less data goes over the wire and your server does much less work. In Safari and Firefox that is switched off, and uploads fall back to the older server-side path. This plugin switches it back on.
+
+There is nothing to configure - activate the plugin and it works. Chrome is unaffected, because WordPress already handles it there.
+
+One thing to know before you install: this works by turning on cross-origin isolation, which is a real security boundary and can affect embeds and third-party media inside the editor. It is worth reading the [Tradeoffs](#tradeoffs) section first.
+
 ## Features
 
 ### Cross-Origin Isolation (COEP/COOP)

--- a/client-side-media-everywhere.php
+++ b/client-side-media-everywhere.php
@@ -3,7 +3,7 @@
  * Plugin Name: Client-Side Media Everywhere
  * Plugin URI:  https://github.com/adamsilverstein/client-side-media-everywhere
  * Description: Enables client-side media processing on Firefox and Safari via COEP/COOP cross-origin isolation headers.
- * Version:     1.1.0
+ * Version:     1.1.1
  * Requires at least: 6.8
  * Requires PHP: 7.4
  * Author:      Adam Silverstein
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'CSME_VERSION', '1.1.0' );
+define( 'CSME_VERSION', '1.1.1' );
 define( 'CSME_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'CSME_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "client-side-media-everywhere",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"private": true,
 	"description": "WordPress plugin enabling client-side media processing on Firefox and Safari via COEP/COOP headers.",
 	"license": "GPL-2.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -12,13 +12,23 @@ Enables client-side media processing on Firefox and Safari via COEP/COOP cross-o
 
 == Description ==
 
+**In one sentence: this plugin gets client-side media processing working in Safari and Firefox, which WordPress otherwise only does in Chrome.**
+
+When you upload an image in Chrome, WordPress resizes and compresses it on your own device before it is sent, so less data goes over the wire and your server does much less work. In Safari and Firefox that is switched off, and uploads fall back to the older server-side path. This plugin switches it back on.
+
+There is nothing to configure - activate the plugin and it works. Chrome is unaffected, because WordPress already handles it there.
+
+One thing to know before you install: this works by turning on cross-origin isolation, which is a real security boundary and can affect embeds and third-party media inside the editor. It is worth reading the Tradeoffs section below first.
+
+**Why WordPress switches it off:**
+
 WordPress 7.1 and Gutenberg include client-side media processing powered by WebAssembly (wasm-vips). This requires cross-origin isolation, which is achieved via Document-Isolation-Policy (DIP) on Chrome 137+.
 
 However, Firefox and Safari do not yet support DIP, and neither does Chrome before 137, so client-side media processing is disabled on those browsers.
 
 This plugin restores support for Firefox and Safari by sending the older COEP/COOP headers (Cross-Origin-Embedder-Policy / Cross-Origin-Opener-Policy) on browsers where DIP is not available.
 
-**What this plugin does:**
+**Under the hood:**
 
 * Sends `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: credentialless` (or `require-corp` on Safari) headers in the block editor.
 * Adds `crossorigin="anonymous"` attributes to cross-origin resources.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: adamsilverstein
 Tags: media, safari, firefox, performance, cross-origin
 Requires at least: 6.8
 Tested up to: 7.1
-Stable tag: 1.1.0
+Stable tag: 1.1.1
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -90,6 +90,11 @@ To keep the plugin active but suppress the headers programmatically (for example
 WordPress 7.1 converts HEIC images client-side where possible and server-side otherwise. This plugin no longer includes any HEIC handling of its own.
 
 == Changelog ==
+
+= 1.1.1 =
+* Reworked the description to open with a plain explanation of what the plugin does, instead of leading with wasm-vips, Document-Isolation-Policy and COEP/COOP. The technical explanation is still there, further down.
+* Added `safari` and `firefox` to the plugin tags, since that is what people are likely searching for.
+* No functional changes: the plugin code is identical to 1.1.0.
 
 = 1.1.0 =
 * Renamed the plugin from "Client-Side Media Experiments" to "Client-Side Media Everywhere" to better describe what it does: bringing the WordPress client-side media processing feature to browsers that core does not cover.

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Client-Side Media Everywhere ===
 Contributors: adamsilverstein
-Tags: media, performance, cross-origin, wasm
+Tags: media, safari, firefox, performance, cross-origin
 Requires at least: 6.8
 Tested up to: 7.1
 Stable tag: 1.1.0

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,7 +6,7 @@
  */
 
 // Define plugin constants.
-define( 'CSME_VERSION', '1.1.0' );
+define( 'CSME_VERSION', '1.1.1' );
 define( 'CSME_PLUGIN_DIR', dirname( __DIR__ ) . '/' );
 define( 'CSME_PLUGIN_URL', 'http://example.org/wp-content/plugins/client-side-media-everywhere/' );
 


### PR DESCRIPTION
Looking at the published page - https://wordpress.org/plugins/client-side-media-everywhere/ - the description opens with wasm-vips, Document-Isolation-Policy and COEP/COOP before it gets around to saying what the plugin is for. wordpress.org does not render the short description anywhere near the title, so the first thing a visitor actually reads is the mechanism, and they have to get to the third paragraph before Safari and Firefox come up.

This puts a short plain-language explanation at the top and leaves the existing technical write-up underneath it, under a "Why WordPress switches it off" heading. The old "What this plugin does" bullets are still there, renamed to "Under the hood" so there are not two sections claiming to explain the same thing.

The new opening is four short paragraphs: what you get, that there is nothing to configure, that Chrome is unaffected, and a pointer to the Tradeoffs section before installing.

## How has this been tested

- Confirmed the problem first by fetching the live page and checking what renders above the fold - there is no tagline shown, so the short description in the readme header is not doing the job I assumed it was.
- Checked the short description is still within the wordpress.org 150 character limit (it is 104, and I did not change it).
- Re-read the rendered section order in readme.txt to confirm Description still flows into Tradeoffs, Installation and FAQ as before.

I have not previewed this through the wordpress.org readme renderer, so the heading style is the part I am least sure of - I used bold rather than `= =` to match what the file already does.

## Types of changes

- Add a plain-language "what this plugin does" opening to the Description in readme.txt.
- Mirror the same opening in README.md under a "What this plugin does" heading.
- Move the existing wasm-vips / DIP explanation under "Why WordPress switches it off".
- Rename the technical bullets from "What this plugin does" to "Under the hood".
- Second commit, separate so it is easy to drop: add `safari` and `firefox` to the tags, dropping `wasm` to stay within the five tag limit.

Note: the description is bundled into the plugin readme, so this only reaches wordpress.org on the next release - it will not update the live page on its own.